### PR TITLE
request: override metadata field with None

### DIFF
--- a/invenio_requests/records/api.py
+++ b/invenio_requests/records/api.py
@@ -33,6 +33,9 @@ class Request(Record):
 
     id = IdentityField("external_id")
 
+    metadata = None
+    """Disabled metadata field from the base class."""
+
     # TODO figure out aliases, multiple mappings, common search fields
     index = IndexField("requests-request-v1.0.0", search_alias="requests")
 


### PR DESCRIPTION
Note that this only shadows the metadata system field from the parent class but does not completely remove it (`del Request.metadata` will make the original system field appear again), and accessing `Request.metadata` or `req.metadata` will return `None` rather than raise an `AttributeError`.
It looks like the easiest way of getting rid of this field for good would be to use `invenio_records.api.Record` (and `invenio_records.systemfields.SystemFieldsMixin`) as base class, rather than `invenio_records_resources.record.api.Record` and adding all the other fields defined in the latter class... Though that's a trade-off with duplication of code.

closes #16 