### PR TITLE
42 comment on accept decline cancel

### DIFF
--- a/invenio_requests/customizations/base/actions.py
+++ b/invenio_requests/customizations/base/actions.py
@@ -8,7 +8,10 @@
 
 """Base class for customizable actions on requests."""
 
+from invenio_db import db
+
 from ...errors import CannotExecuteActionError, NoSuchActionError
+from ...proxies import current_requests
 
 
 class RequestAction:
@@ -47,6 +50,14 @@ class RequestAction:
         As such, it can be used to index records, for instance.
         """
         pass
+
+    def _commit(self):
+        """Persist changes."""
+        self.request.commit()
+        db.session.commit()
+        requests_service = current_requests.requests_service
+        if requests_service.indexer:
+            requests_service.indexer.index(self.request)
 
 
 class RequestActions:

--- a/invenio_requests/customizations/default/actions.py
+++ b/invenio_requests/customizations/default/actions.py
@@ -10,8 +10,10 @@
 
 
 from invenio_access.permissions import system_process
-from invenio_db import db
 
+from ...proxies import current_requests
+from ...records.api import RequestEventFormat, RequestEventType
+from ..base import RequestAction
 
 
 class SubmitAction(RequestAction):
@@ -99,8 +101,15 @@ class DeclineAction(RequestAction):
             identity,
             request_id,
             {
-                **data,
                 "type": RequestEventType.DECLINED.value,
+            }
+        )
+        events_service.create(
+            identity,
+            request_id,
+            {
+                **data,
+                "type": RequestEventType.COMMENT.value,
             }
         )
 
@@ -126,8 +135,15 @@ class CancelAction(RequestAction):
             identity,
             request_id,
             {
-                **data,
                 "type": RequestEventType.CANCELLED.value,
+            }
+        )
+        events_service.create(
+            identity,
+            request_id,
+            {
+                **data,
+                "type": RequestEventType.COMMENT.value,
             }
         )
 

--- a/invenio_requests/resources/events/resources.py
+++ b/invenio_requests/resources/events/resources.py
@@ -138,12 +138,10 @@ class RequestCommentsResource(RecordResource):
     @response_handler()
     def update(self):
         """Update a comment."""
-        data = deepcopy(resource_requestctx.data)
-        data["type"] = RequestEventType.COMMENT.value
         item = self.service.update(
             identity=g.identity,
             id_=resource_requestctx.view_args["comment_id"],
-            data=data,
+            data=resource_requestctx.data,
             revision_id=resource_requestctx.headers.get("if_match"),
         )
         return item.to_dict(), 200

--- a/tests/services/events/test_request_events_service.py
+++ b/tests/services/events/test_request_events_service.py
@@ -84,3 +84,22 @@ def test_delete_wipes_content(identity_simple, events_service_data, example_requ
         read_deleted_item_dict = read_deleted_item.to_dict()
         assert item_dict["type"] == read_deleted_item_dict["type"]
         assert "" == read_deleted_item_dict["content"]
+
+
+def test_update_keeps_type(identity_simple, events_service_data, example_request):
+    # The `update`` service method can't be used to change the type
+    events_service = current_requests.request_events_service
+    request_id = example_request.number
+    # event type is COMMENT by default
+    item = events_service.create(identity_simple, request_id, events_service_data)
+    comment_id = item.id
+    item_dict = item.to_dict()
+    data = {
+        **events_service_data,
+        "type": RequestEventType.ACCEPTED.value
+    }
+
+    updated_item = events_service.update(identity_simple, comment_id, data)
+
+    updated_item_dict = updated_item.to_dict()
+    assert item_dict["type"] == updated_item_dict["type"]

--- a/tests/services/requests/test_requests_service.py
+++ b/tests/services/requests/test_requests_service.py
@@ -120,7 +120,7 @@ def test_accept_request(
 
     assert "accepted" == result_dict["status"]
     results = request_events_service.search(identity_simple_2, id_)
-    assert 2 == results.total  # submit comment + accept
+    assert 3 == results.total  # submit comment + accept + comment
     hits = list(results.hits)
     assert 1 == len([h for h in hits if RequestEventType.ACCEPTED.value == h["type"]])
 
@@ -144,7 +144,7 @@ def test_cancel_request(
 
     assert "cancelled" == result_dict["status"]
     results = request_events_service.search(identity_simple, id_)
-    assert 2 == results.total  # submit comment + cancel
+    assert 3 == results.total  # submit comment + cancel + comment
     hits = list(results.hits)
     assert 1 == len([h for h in hits if RequestEventType.CANCELLED.value == h["type"]])
 
@@ -168,6 +168,6 @@ def test_decline_request(
 
     assert "declined" == result_dict["status"]
     results = request_events_service.search(identity_simple, id_)
-    assert 2 == results.total  # submit comment + decline
+    assert 3 == results.total  # submit comment + decline + comment
     hits = list(results.hits)
     assert 1 == len([h for h in hits if RequestEventType.DECLINED.value == h["type"]])


### PR DESCRIPTION
- Request: comment on submit, accept, cancel and decline; closes #42
- Accept/Decline/Cancel event; closes #28  
- guarantee RequestEvent type immutability via `update`; closes #47 
- alter semantics of delete; closes #46
