### PR TITLE
search: add filters for entity references

### DIFF
--- a/invenio_requests/resources/fields.py
+++ b/invenio_requests/resources/fields.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 TU Wien.
+#
+# Invenio-Requests is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Marshmallow fields for search parameter deserialization."""
+
+from marshmallow import fields
+
+
+class ReferenceString(fields.Field):
+    """Field for serializing reference querystring parameters into reference dicts.
+
+    Reference querystring parameters are of the shape ``"TYPE:ID"``, which are
+    deserialized into reference dicts of the shape ``{"TYPE": "ID"}``.
+    """
+
+    #: Default error messages.
+    default_error_messages = {
+        "invalid": "Not a valid reference.",
+    }
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        """Deserialize reference string into a dict."""
+        if value is None:
+            return None
+        elif ":" not in value:
+            raise self.make_error("invalid")
+
+        # if there's multiple colons, we assume the first one is the separator
+        type_, id_ = value.split(":", 1)
+        return {type_: id_}
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        """Serialize the reference dict to a reference string."""
+        # TODO do we even need this?
+        if not isinstance(value, dict) or len(value) != 1:
+            # a reference dict needs to have exactly one key
+            raise self.make_error("invalid")
+
+        key, value = list(value.items())[0]
+        return f"{key}:{value}"

--- a/invenio_requests/resources/resource.py
+++ b/invenio_requests/resources/resource.py
@@ -33,6 +33,8 @@ from invenio_records_resources.resources.records.resource import (
 )
 from invenio_records_resources.resources.records.utils import es_preference
 
+from .fields import ReferenceString
+
 
 #
 # Request args
@@ -40,8 +42,9 @@ from invenio_records_resources.resources.records.utils import es_preference
 class RequestSearchRequestArgsSchema(SearchRequestArgsSchema):
     """Add parameter to parse tags."""
 
-    # TODO what do we need here?
-    pass
+    created_by = ReferenceString()
+    topic = ReferenceString()
+    receiver = ReferenceString()
 
 
 #

--- a/invenio_requests/services/requests/config.py
+++ b/invenio_requests/services/requests/config.py
@@ -10,7 +10,7 @@
 
 """Requests service configuration."""
 
-from invenio_records_resources.services import RecordServiceConfig
+from invenio_records_resources.services import RecordServiceConfig, SearchOptions
 from invenio_records_resources.services.records.components import DataComponent
 from invenio_records_resources.services.records.links import pagination_links
 
@@ -20,6 +20,7 @@ from ..permissions import PermissionPolicy
 from .components import ExternalIdentifierComponent
 from .customization import RequestsConfigMixin
 from .links import RequestLink
+from .params import ReferenceFilterParam
 from .results import RequestItem, RequestList
 
 
@@ -30,6 +31,16 @@ def _is_action_available(request, context):
     return RequestActions.can_execute(identity, request, action)
 
 
+class RequestSearchOptions(SearchOptions):
+    """Search options."""
+
+    params_interpreters_cls = SearchOptions.params_interpreters_cls + [
+        ReferenceFilterParam.factory(param="created_by", field="created_by"),
+        ReferenceFilterParam.factory(param="receiver", field="receiver"),
+        ReferenceFilterParam.factory(param="topic", field="topic"),
+    ]
+
+
 class RequestsServiceConfig(RecordServiceConfig, RequestsConfigMixin):
     """Requests service configuration."""
 
@@ -37,6 +48,7 @@ class RequestsServiceConfig(RecordServiceConfig, RequestsConfigMixin):
     permission_policy_cls = PermissionPolicy
     result_item_cls = RequestItem
     result_list_cls = RequestList
+    search = RequestSearchOptions
 
     # request-specific configuration
     record_cls = Request  # needed for model queries

--- a/invenio_requests/services/requests/params.py
+++ b/invenio_requests/services/requests/params.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 TU Wien.
+#
+# Invenio-Requests is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Search parameter interpreters for requests."""
+
+from invenio_records_resources.services.records.params import FilterParam
+
+from ...resolvers.registry import ResolverRegistry
+
+
+class ReferenceFilterParam(FilterParam):
+    """Filter for reference dictionaries."""
+
+    def __init__(self, param_name, field_name, config):
+        """Constructor."""
+        super().__init__(param_name, field_name, config)
+        self._match_cache = {}
+
+    def _is_valid(self, ref_type, ref_id):
+        """Check if the reference dict is potentially resolvable."""
+        if ref_type in self._match_cache:
+            return self._match_cache[ref_type]
+
+        # check if there's any resolver registered for the dict
+        is_valid = any(
+            (
+                res.matches_reference_dict({ref_type: ref_id})
+                for res in ResolverRegistry().get_registered_resolvers()
+            )
+        )
+        self._match_cache[ref_type] = is_valid
+        return is_valid
+
+    def apply(self, identity, search, params):
+        """Apply filter for a potentially resolvable reference dict."""
+        if self.param_name not in params:
+            return search
+
+        ref_dict = params.pop(self.param_name, None)
+        ref_type, ref_id = list(ref_dict.items())[0]
+
+        # only apply the filter if it is potentially resolvable
+        if self._is_valid(ref_type, ref_id):
+            field_name = f"{self.field_name}.{ref_type}"
+            if isinstance(ref_id, str):
+                search = search.filter("term", **{field_name: ref_id})
+            else:
+                search = search.filter("terms", **{field_name: ref_id})
+
+        return search

--- a/invenio_requests/services/requests/service.py
+++ b/invenio_requests/services/requests/service.py
@@ -105,26 +105,6 @@ class RequestsService(RecordService):
             links_tpl=self.links_item_tpl,
         )
 
-    def read_all(self, identity, fields, max_records=150, **kwargs):
-        """Search for records matching the querystring."""
-        # TODO check later
-        return super().read_all(identity, fields, max_records=max_records, **kwargs)
-
-    def read_many(self, identity, ids, fields=None, **kwargs):
-        """Search for requests matching the ids."""
-        # TODO check later
-        return super().read_many(identity, ids, fields=fields, **kwargs)
-
-    def scan(self, identity, params=None, es_preference=None, **kwargs):
-        """Scan for requests matching the querystring."""
-        # TODO check later
-        return super().scan(identity, params=None, es_preference=None, **kwargs)
-
-    def search(self, identity, params=None, es_preference=None, **kwargs):
-        """Search for records matching the querystring."""
-        # TODO check later
-        return super().search(identity, es_preference=None, **kwargs)
-
     def update(self, id_, identity, data):
         """Replace a request."""
         request = self.record_cls.get_record(id_)

--- a/tests/resources/events/test_request_events_resources.py
+++ b/tests/resources/events/test_request_events_resources.py
@@ -36,9 +36,7 @@ def test_simple_comment_flow(
 
     # User 1 comments
     response = client.post(
-        f"/requests/{request_id}/comments",
-        headers=headers,
-        json=events_resource_data
+        f"/requests/{request_id}/comments", headers=headers, json=events_resource_data
     )
 
     comment_id = response.json["id"]
@@ -66,9 +64,7 @@ def test_simple_comment_flow(
     # User 2 comments
     client = client_logged_as("user2@example.org")
     response = client.post(
-        f"/requests/{request_id}/comments",
-        headers=headers,
-        json=events_resource_data
+        f"/requests/{request_id}/comments", headers=headers, json=events_resource_data
     )
     comment_id = response.json["id"]
     revision_id = response.json["revision_id"]
@@ -108,10 +104,7 @@ def test_simple_comment_flow(
     RequestEvent.index.refresh()
 
     # User 2 gets the timeline (will be sorted)
-    response = client.get(
-        f"/requests/{request_id}/timeline",
-        headers=headers
-    )
+    response = client.get(f"/requests/{request_id}/timeline", headers=headers)
     assert 200 == response.status_code
     assert 2 == response.json["hits"]["total"]
     assert_api_response_json(expected_json_1, response.json["hits"]["hits"][0])
@@ -127,14 +120,13 @@ def test_simple_comment_flow(
 
 
 def test_timeline_links(
-        client_logged_as, events_resource_data, example_request, headers):
+    client_logged_as, events_resource_data, example_request, headers
+):
     """Tests the links for the timeline (search) endpoint."""
     client = client_logged_as("user1@example.org")
     request_id = example_request.id
     response = client.post(
-        f"/requests/{request_id}/comments",
-        headers=headers,
-        json=events_resource_data
+        f"/requests/{request_id}/comments", headers=headers, json=events_resource_data
     )
 
     response = client.get(f"/requests/{request_id}/timeline", headers=headers)

--- a/tests/resources/requests/conftest.py
+++ b/tests/resources/requests/conftest.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 TU Wien.
+#
+# Invenio-Requests is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Request resource conftest."""
+
+import pytest
+from invenio_access.permissions import system_identity as sys_id
+
+from invenio_requests.customizations.default import DefaultRequestType
+
+
+@pytest.fixture()
+def example_requests(app, users):
+    """A few example requests."""
+    svc = app.extensions["invenio-requests"].requests_service
+
+    u1, u2, u3 = users
+    req1 = svc.create(
+        sys_id, {"title": "first"}, DefaultRequestType, receiver=u1, creator=u3
+    )._obj
+    req2 = svc.create(
+        sys_id, {"title": "second"}, DefaultRequestType, receiver=u1, creator=u3
+    )._obj
+    req3 = svc.create(
+        sys_id, {"title": "third"}, DefaultRequestType, receiver=u2, creator=u3
+    )._obj
+
+    # this is needed to make sure that the requests are indexed in time,
+    # before the tests are run
+    req1.index.refresh()
+    req2.index.refresh()
+    req3.index.refresh()
+
+    return [req1, req2, req3]

--- a/tests/resources/requests/test_requests_resources.py
+++ b/tests/resources/requests/test_requests_resources.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 TU Wien.
+#
+# Invenio-Requests is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Request resource tests."""
+
+import copy
+
+from invenio_requests.records.api import RequestEvent, RequestEventType
+
+
+def check_reference_search_filter_results(response, expected_hits, expected_req_nums):
+    """Check if all expected results are there."""
+    hits = response.json["hits"]["hits"]
+    reported_hits = int(response.json["hits"]["total"])
+    req_numbers = [r["number"] for r in response.json["hits"]["hits"]]
+
+    assert len(req_numbers) == len(expected_req_nums)
+    for num in expected_req_nums:
+        assert num in req_numbers
+
+    assert reported_hits == len(hits) == expected_hits
+
+
+def test_reference_search_filters(app, client_logged_as, headers, example_requests):
+    """Test if the reference search filters (e.g. receiver=user:1) work as intended."""
+    # use the admin with superuser-access to evade potential permission issues
+    client = client_logged_as("admin@example.org")
+    req1, req2, req3 = example_requests
+    request_id = req1.id
+
+    # get unfiltered responses
+    response = client.get(
+        f"/requests/",
+        headers=headers,
+    )
+    check_reference_search_filter_results(
+        response, 3, [req1.number, req2.number, req3.number]
+    )
+
+    # get requests where user #1 is the receiver (should be the first two)
+    response = client.get(
+        f"/requests/?receiver=user:1",
+        headers=headers,
+    )
+    check_reference_search_filter_results(response, 2, [req1.number, req2.number])
+
+    # get requests where user #2 is the receiver (should be the last one)
+    response = client.get(
+        f"/requests/?receiver=user:2",
+        headers=headers,
+    )
+    check_reference_search_filter_results(response, 1, [req3.number])
+
+    # get requests where user #3 is the receiver (none)
+    response = client.get(
+        f"/requests/?receiver=user:3",
+        headers=headers,
+    )
+    check_reference_search_filter_results(response, 0, [])
+
+    # check what happens when there's an invalid reference
+    # (the filter should get dropped)
+    response = client.get(
+        f"/requests/?receiver=nosuchthing:1",
+        headers=headers,
+    )
+    check_reference_search_filter_results(
+        response, 3, [req1.number, req2.number, req3.number]
+    )


### PR DESCRIPTION
* add reference strings (of the shape 'TYPE:ID') as filters for searches
* they are available for the fields 'receiver', 'created_by', and 'topic'

note that this PR doesn't yet allow multiple reference strings for the same field (that is, e.g. `receiver=TYPE:ID` could only be specified once per querystring).