### PR TITLE
services: dynamic payload schemas

### DIFF
--- a/invenio_requests/registry.py
+++ b/invenio_requests/registry.py
@@ -39,15 +39,7 @@ class TypeRegistry:
             self.register_type(t)
 
     def register_type(self, type_, force=False):
-        """Register the specified request_type.
-
-        :param request_type: The request type to register.
-        :param as_type: Optional, the name under which to register the type.
-                        If not specified, the request_type name from the
-                        request_class will be taken.
-        :param force: Override already registered type, if there is a
-                      different type already registered with the same name.
-        """
+        """Register the specified request_type."""
         type_id = type_.type_id
         type_name = getattr(type_, 'name', type_id)
 
@@ -59,14 +51,7 @@ class TypeRegistry:
             self._registered_names.setdefault(type_name, type_id)
 
     def lookup(self, type_id, quiet=False, default=None):
-        """Look up a registered type by its id.
-
-        :param type_id: The type name to look up.
-        :param quiet: TODO
-        :param default: The default value to return if no type is found and
-                        quiet is set.
-        :return: The type registered for the name.
-        """
+        """Look up a registered type by its id."""
         if not quiet:
             return self._registered_types[type_id]
 

--- a/invenio_requests/services/schemas.py
+++ b/invenio_requests/services/schemas.py
@@ -12,7 +12,7 @@
 from datetime import timezone
 
 from invenio_records_resources.services.records.schema import BaseRecordSchema
-from marshmallow import Schema, fields, missing, validate
+from marshmallow import RAISE, Schema, fields, missing, validate
 from marshmallow_oneofschema import OneOfSchema
 from marshmallow_utils import fields as utils_fields
 
@@ -32,13 +32,16 @@ class EntityReferenceSchema(Schema):
 
 
 class RequestSchema(BaseRecordSchema):
-    """Schema for requests."""
+    """Schema for requests.
+
+    Note that the payload schema is dynamically constructed and injected into
+    this schema.
+    """
 
     number = fields.String(dump_only=True)
     request_type = fields.String()
     title = utils_fields.SanitizedUnicode(default='')
     description = utils_fields.SanitizedUnicode()
-    payload = fields.Dict(dump_only=True)
 
     # routing information can likely be inferred during creation
     created_by = fields.Nested(EntityReferenceSchema)
@@ -51,6 +54,11 @@ class RequestSchema(BaseRecordSchema):
     expires_at = utils_fields.TZDateTime(
         timezone=timezone.utc, format="iso", dump_only=True)
     is_expired = fields.Boolean(dump_only=True)
+
+    class Meta:
+        """Schema meta."""
+
+        unknown = RAISE
 
 
 class ModelFieldStr(fields.Str):


### PR DESCRIPTION
With this change, a request type can only change the payload schema, and not the entire schema.