### PR TITLE
Requests: allow specification of allowed entity reference types

### DIFF
--- a/invenio_requests/customizations/base/request_types.py
+++ b/invenio_requests/customizations/base/request_types.py
@@ -68,6 +68,24 @@ class RequestType:
     different or more specific schema.
     """
 
+    creator_can_be_none = True
+    """Determines if the ``created_by`` reference accepts ``None``."""
+
+    receiver_can_be_none = False
+    """Determines if the ``receiver`` reference accepts ``None``."""
+
+    topic_can_be_none = True
+    """Determines if the ``topic`` reference accepts ``None``."""
+
+    allowed_creator_ref_types = ["user"]
+    """A list of allowed TYPE keys for ``created_by`` reference dicts."""
+
+    allowed_receiver_ref_types = ["user"]
+    """A list of allowed TYPE keys for ``receiver`` reference dicts."""
+
+    allowed_topic_ref_types = []
+    """A list of allowed TYPE keys for ``topic`` reference dicts."""
+
     def generate_external_id(self, request, **kwargs):
         """Generate a new external identifier.
 

--- a/invenio_requests/records/api.py
+++ b/invenio_requests/records/api.py
@@ -27,6 +27,11 @@ from .systemfields import (
     RequestStatusField,
     RequestTypeField,
 )
+from .systemfields.entity_reference import (
+    check_allowed_creators,
+    check_allowed_receivers,
+    check_allowed_topics,
+)
 
 
 class Request(Record):
@@ -65,13 +70,13 @@ class Request(Record):
     custom request actions are registered.
     """
 
-    topic = ReferencedEntityField("topic")
+    topic = ReferencedEntityField("topic", check_allowed_topics)
     """Topic (associated object) of the request."""
 
-    created_by = ReferencedEntityField("created_by")
+    created_by = ReferencedEntityField("created_by", check_allowed_creators)
     """The entity that created the request."""
 
-    receiver = ReferencedEntityField("receiver")
+    receiver = ReferencedEntityField("receiver", check_allowed_receivers)
     """The entity that will receive the request."""
 
     status = RequestStatusField("status")

--- a/invenio_requests/records/jsonschemas/requests/definitions-v1.0.0.json
+++ b/invenio_requests/records/jsonschemas/requests/definitions-v1.0.0.json
@@ -5,7 +5,7 @@
   "additionalProperties": false,
   "entity_reference": {
     "description": "Reference to an entity, with the type as key and ID as value",
-    "type": "object",
+    "type": ["object", "null"],
     "additionalProperties": false,
     "patternProperties": {
       "^[a-z_]+$": {

--- a/invenio_requests/records/systemfields/entity_reference.py
+++ b/invenio_requests/records/systemfields/entity_reference.py
@@ -7,6 +7,8 @@
 
 """Systemfield for managing referenced entities in request."""
 
+from functools import partial
+
 from invenio_records.systemfields import SystemField
 
 from ...resolvers.base import EntityProxy
@@ -16,6 +18,18 @@ from ...resolvers.registry import ResolverRegistry
 class ReferencedEntityField(SystemField):
     """Systemfield for managing the request type."""
 
+    def __init__(self, key=None, reference_check_func=None):
+        """Constructor."""
+        super().__init__(key=key)
+        self._ref_check = reference_check_func
+
+    def _check_reference(self, instance, ref_dict):
+        """Check if the reference is accepted."""
+        if self._ref_check is None:
+            return True
+
+        return self._ref_check(instance, ref_dict)
+
     def set_obj(self, instance, obj):
         """Set the referenced entity."""
         # allow the setter to be used with a reference dict,
@@ -23,8 +37,12 @@ class ReferencedEntityField(SystemField):
         if not isinstance(obj, dict):
             if isinstance(obj, EntityProxy):
                 obj = obj.reference_dict
-            else:
+            elif obj is not None:
                 obj = ResolverRegistry.reference_entity(obj, raise_=True)
+
+        # check if the reference is allowed
+        if not self._check_reference(instance, obj):
+            raise ValueError(f"Invalid reference for '{self.key}': {obj}")
 
         # set dictionary key and reset the cache
         self.set_dictkey(instance, obj)
@@ -42,6 +60,10 @@ class ReferencedEntityField(SystemField):
             return obj
 
         reference_dict = self.get_dictkey(instance)
+        if reference_dict is None:
+            # TODO maybe use a `NullProxy` instead?
+            return None
+
         obj = ResolverRegistry.resolve_entity_proxy(reference_dict)
         self._set_cache(instance, obj)
         return obj
@@ -53,3 +75,39 @@ class ReferencedEntityField(SystemField):
             return self
 
         return self.obj(record)
+
+
+def check_allowed_references(get_allows_none, get_allowed_types, request, ref_dict):
+    """Check the reference according to rules specific to requests.
+
+    In case the ``ref_dict`` is ``None``, it will check if this is allowed for the
+    reference at hand.
+    Otherwise, it will check if the reference dict's key (i.e. the TYPE) is allowed.
+    """
+    if ref_dict is None:
+        return get_allows_none(request)
+
+    ref_type = list(ref_dict.keys())[0]
+    return ref_type in get_allowed_types(request)
+
+
+check_allowed_creators = partial(
+    check_allowed_references,
+    lambda r: r.request_type.creator_can_be_none,
+    lambda r: r.request_type.allowed_creator_ref_types,
+)
+"""Check function specific for the ``created_by`` field of requests."""
+
+check_allowed_receivers = partial(
+    check_allowed_references,
+    lambda r: r.request_type.receiver_can_be_none,
+    lambda r: r.request_type.allowed_receiver_ref_types,
+)
+"""Check function specific for the ``receiver`` field of requests."""
+
+check_allowed_topics = partial(
+    check_allowed_references,
+    lambda r: r.request_type.topic_can_be_none,
+    lambda r: r.request_type.allowed_topic_ref_types,
+)
+"""Check function specific for the ``topic`` field of requests."""

--- a/invenio_requests/services/requests/components.py
+++ b/invenio_requests/services/requests/components.py
@@ -18,3 +18,13 @@ class ExternalIdentifierComponent(ServiceComponent):
     def create(self, identity, data=None, record=None, **kwargs):
         """Create identifier when record is created."""
         type(record).number.assign(record)
+
+
+class EntityReferencesComponent(ServiceComponent):
+    """Component for initializing a request's entity references."""
+
+    def create(self, identity, data=None, record=None, **kwargs):
+        """Initialize the entity reference fields of a request."""
+        for field in ("created_by", "receiver", "topic"):
+            if field in kwargs:
+                setattr(record, field, kwargs[field])

--- a/invenio_requests/services/requests/config.py
+++ b/invenio_requests/services/requests/config.py
@@ -17,7 +17,7 @@ from invenio_records_resources.services.records.links import pagination_links
 from ...customizations.base import RequestActions
 from ...records.api import Request
 from ..permissions import PermissionPolicy
-from .components import ExternalIdentifierComponent
+from .components import EntityReferencesComponent, ExternalIdentifierComponent
 from .customization import RequestsConfigMixin
 from .links import RequestLink
 from .results import RequestItem, RequestList
@@ -53,5 +53,6 @@ class RequestsServiceConfig(RecordServiceConfig, RequestsConfigMixin):
     components = [
         # Order of components are important!
         DataComponent,
+        EntityReferencesComponent,
         ExternalIdentifierComponent,
     ]


### PR DESCRIPTION
* add mechanism to RequestType to allow the specification of explicitly allowed reference types (i.e. set of allowed TYPEs in reference dicts) for creators, receivers, and topics
* initialization of entity references was moved to the components, as the initialization via '.create()' did not trigger system fields

closes #36 