### PR TITLE
schemas: construct entity reference schema dynamically

### DIFF
--- a/invenio_requests/customizations/default/request_types.py
+++ b/invenio_requests/customizations/default/request_types.py
@@ -77,13 +77,6 @@ class DefaultRequestType(RequestType):
     argument.
     """
 
-    marshmallow_schema = RequestSchema
-    """Schema used for de/serialization of requests of this type.
-
-    To be overridden in subclasses, if the custom request type follows a
-    different or more specific schema.
-    """
-
     def generate_request_number(self, request, **kwargs):
         """Generate a new request number.
 

--- a/invenio_requests/records/systemfields/request_type.py
+++ b/invenio_requests/records/systemfields/request_type.py
@@ -7,6 +7,8 @@
 
 """Request type systemfield for request records."""
 
+import inspect
+
 from invenio_records.systemfields import SystemField
 
 from ...customizations.base import RequestType
@@ -31,8 +33,8 @@ class RequestTypeField(SystemField):
         """Set the request type."""
         assert record is not None
 
-        if isinstance(value, type):
-            # TODO is there a nicer way of doing this?
+        if inspect.isclass(value):
+            # if a class was passed rather than an instance, try to instantiate it
             value = value()
 
         if not isinstance(value, RequestType):

--- a/invenio_requests/services/requests/results.py
+++ b/invenio_requests/services/requests/results.py
@@ -32,7 +32,7 @@ class RequestItem(RecordItem):
         self._request = request
         self._service = service
         self._links_tpl = links_tpl
-        self._schema = schema or service._wrap_schema(request.type.marshmallow_schema)
+        self._schema = schema or service._wrap_schema(request.type.marshmallow_schema())
 
     @property
     def id(self):
@@ -119,7 +119,7 @@ class RequestList(RecordList):
         for hit in self._results:
             # load dump
             request = request_cls.loads(hit.to_dict())
-            schema = self._service._wrap_schema(request.type.marshmallow_schema)
+            schema = self._service._wrap_schema(request.type.marshmallow_schema())
 
             # project the request
             projection = schema.dump(

--- a/invenio_requests/services/requests/service.py
+++ b/invenio_requests/services/requests/service.py
@@ -47,7 +47,7 @@ class RequestsService(RecordService):
         self.require_permission(identity, "create")
 
         # we're not using "self.schema" b/c the schema may differ per request type!
-        schema = self._wrap_schema(request_type.marshmallow_schema)
+        schema = self._wrap_schema(request_type.marshmallow_schema())
         data, errors = schema.load(
             data,
             context={"identity": identity},
@@ -106,7 +106,7 @@ class RequestsService(RecordService):
             self,
             identity,
             request,
-            schema=self._wrap_schema(request.type.marshmallow_schema),
+            schema=self._wrap_schema(request.type.marshmallow_schema()),
             links_tpl=self.links_item_tpl,
         )
 
@@ -121,7 +121,7 @@ class RequestsService(RecordService):
         self.require_permission(identity, "update", record=request)
 
         # we're not using "self.schema" b/c the schema may differ per request type!
-        schema = self._wrap_schema(request.type.marshmallow_schema)
+        schema = self._wrap_schema(request.type.marshmallow_schema())
         data, _ = schema.load(
             data,
             context={
@@ -224,6 +224,6 @@ class RequestsService(RecordService):
             self,
             identity,
             request,
-            schema=self._wrap_schema(request.type.marshmallow_schema),
+            schema=self._wrap_schema(request.type.marshmallow_schema()),
             links_tpl=self.links_item_tpl,
         )


### PR DESCRIPTION
* only allow a single key to be present
* instead of allowing a fixed set of keys, create the set of accepted keys dynamically based on the request type, similar to the payload

closes #39 