### PR TITLE
resolvers: harmonize no result found exeception

### DIFF
--- a/invenio_requests/resolvers/default/records.py
+++ b/invenio_requests/resolvers/default/records.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2021 CERN.
 #
 # Invenio-Requests is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
 """Resolver for records."""
+
+from sqlalchemy.exc import StatementError
+from sqlalchemy.orm.exc import NoResultFound
 
 from ..base import EntityProxy, EntityResolver
 
@@ -38,7 +42,10 @@ class RecordPKProxy(RecordProxy):
     def _resolve(self):
         """Resolve the Record from the proxy's reference dict."""
         id_ = self._parse_ref_dict_id(self._ref_dict)
-        return self.record_cls.get_record(id_)
+        try:
+            return self.record_cls.get_record(id_)
+        except StatementError as exc:
+            raise NoResultFound() from exc
 
 
 class RecordResolver(EntityResolver):

--- a/invenio_requests/resolvers/default/requests.py
+++ b/invenio_requests/resolvers/default/requests.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2021 CERN.
 #
 # Invenio-Requests is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
 """Resolver and proxy for requests."""
+
+from sqlalchemy.exc import StatementError
+from sqlalchemy.orm.exc import NoResultFound
 
 from ...records.api import Request
 from ..base import EntityProxy, EntityResolver
@@ -18,7 +22,10 @@ class RequestProxy(EntityProxy):
     def _resolve(self):
         """Resolve the Request from the proxy's reference dict."""
         request_id = self._parse_ref_dict_id(self._ref_dict)
-        return Request.get_record(request_id)
+        try:
+            return Request.get_record(request_id)
+        except StatementError as exc:
+            raise NoResultFound() from exc
 
     def get_need(self):
         """Return None since Needs are not applicable to requests."""


### PR DESCRIPTION
* When a non-uuid is given to get_record() you get a StatementError
  instead of NoResultFoundError. In both cases, we're however just
  interested in that a record was not found.