### PR TITLE
request types: add default status for new requests

### DIFF
--- a/invenio_requests/customizations/base/request_types.py
+++ b/invenio_requests/customizations/base/request_types.py
@@ -48,6 +48,12 @@ class RequestType:
     "open" in this state.
     """
 
+    default_status = None
+    """The default status for new requests of this type.
+
+    This must be set to one of the available statuses for the custom request type.
+    """
+
     available_actions = {}
     """Available actions for this Request.
 

--- a/invenio_requests/customizations/default/request_types.py
+++ b/invenio_requests/customizations/default/request_types.py
@@ -58,6 +58,12 @@ class DefaultRequestType(RequestType):
     "open" in this state.
     """
 
+    default_status = "draft"
+    """The default status for new requests of this type.
+
+    This must be set to one of the available statuses for the custom request type.
+    """
+
     available_actions = {
         "submit": SubmitAction,
         "accept": AcceptAction,

--- a/invenio_requests/services/requests/components.py
+++ b/invenio_requests/services/requests/components.py
@@ -28,3 +28,11 @@ class EntityReferencesComponent(ServiceComponent):
         for field in ("created_by", "receiver", "topic"):
             if field in kwargs:
                 setattr(record, field, kwargs[field])
+
+
+class DefaultStatusComponent(ServiceComponent):
+    """Component for initializing the default status of the request."""
+
+    def create(self, identity, data=None, record=None, **kwargs):
+        """Initialize the default status of the request."""
+        record.status = record.type.default_status

--- a/invenio_requests/services/requests/config.py
+++ b/invenio_requests/services/requests/config.py
@@ -17,7 +17,11 @@ from invenio_records_resources.services.records.links import pagination_links
 from ...customizations.base import RequestActions
 from ...records.api import Request
 from ..permissions import PermissionPolicy
-from .components import EntityReferencesComponent, RequestNumberComponent
+from .components import (
+    DefaultStatusComponent,
+    EntityReferencesComponent,
+    RequestNumberComponent,
+)
 from .customization import RequestsConfigMixin
 from .links import RequestLink
 from .params import ReferenceFilterParam
@@ -65,6 +69,7 @@ class RequestsServiceConfig(RecordServiceConfig, RequestsConfigMixin):
     components = [
         # Order of components are important!
         DataComponent,
+        DefaultStatusComponent,
         EntityReferencesComponent,
         RequestNumberComponent,
     ]

--- a/tests/customizations/test_request_types.py
+++ b/tests/customizations/test_request_types.py
@@ -44,6 +44,7 @@ class CustomizedReferenceRequestType(DefaultRequestType):
         "not_closed": RequestState.OPEN,
         "closed": RequestState.CLOSED,
     }
+    default_status = "not_closed"
 
     creator_can_be_none = True
     allowed_creator_ref_types = ["community"]

--- a/tests/services/requests/test_requests_service.py
+++ b/tests/services/requests/test_requests_service.py
@@ -10,8 +10,9 @@
 """Service tests."""
 
 import pytest
-from invenio_records_resources.services.errors import PermissionDeniedError
+from invenio_access.permissions import system_identity
 
+from invenio_requests.customizations.default import DefaultRequestType
 from invenio_requests.records.api import (
     RequestEvent,
     RequestEventFormat,
@@ -130,3 +131,17 @@ def test_decline_request(
     assert 3 == results.total  # submit comment + decline + comment
     hits = list(results.hits)
     assert 1 == len([h for h in hits if RequestEventType.DECLINED.value == h["type"]])
+
+
+@pytest.fixture()
+def test_default_status(users, request_record_input_data, requests_service):
+    """Test if the default status is set on request creation."""
+    request = requests_service.create(
+        system_identity,
+        request_record_input_data,
+        DefaultRequestType,
+        receiver=users[1],
+        creator=users[0],
+    )._request
+
+    assert request.status == request.type.default_status


### PR DESCRIPTION
previously, the status of new requests would be set to `None`, which wasn't exactly what would be expected