### PR TITLE
global: do not register default request type

### DIFF
--- a/invenio_requests/config.py
+++ b/invenio_requests/config.py
@@ -15,7 +15,7 @@ from .services.permissions import PermissionPolicy
 REQUESTS_PERMISSION_POLICY = PermissionPolicy
 """Override the default requests/comments permission policy."""
 
-REQUESTS_REGISTERED_TYPES = [DefaultRequestType()]
+REQUESTS_REGISTERED_TYPES = []
 """Configuration for registered Request Types."""
 
 REQUESTS_ENTITY_RESOLVERS = [

--- a/invenio_requests/customizations/base/request_types.py
+++ b/invenio_requests/customizations/base/request_types.py
@@ -23,7 +23,7 @@ from ...proxies import current_requests
 class RequestType:
     """Base class for custom request types."""
 
-    type_id = "invenio-requests.request"
+    type_id = "base-request"
     """The unique and constant identifier for this type of requests.
 
     Since this property is used to map generic chunks of data from the database
@@ -37,7 +37,7 @@ class RequestType:
     mapped to their `RequestType`).
     """
 
-    name = "Generic Request"
+    name = "Base Request"
     """The human-readable name for this type of requests."""
 
     available_statuses = {}

--- a/invenio_requests/customizations/default/request_types.py
+++ b/invenio_requests/customizations/default/request_types.py
@@ -26,7 +26,7 @@ from .actions import (
 class DefaultRequestType(RequestType):
     """Base class for custom request types."""
 
-    type_id = "invenio-requests.request"
+    type_id = "default-request"
     """The unique and constant identifier for this type of requests.
 
     Since this property is used to map generic chunks of data from the database
@@ -40,7 +40,7 @@ class DefaultRequestType(RequestType):
     mapped to their `RequestType`).
     """
 
-    name = "Generic Request"
+    name = "Default Request"
     """The human-readable name for this type of requests."""
 
     available_statuses = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ def app_config(app_config):
     app_config[
         "RECORDS_REFRESOLVER_STORE"
     ] = "invenio_jsonschemas.proxies.current_refresolver_store"
+    app_config["REQUESTS_REGISTERED_TYPES"] = [DefaultRequestType()]
     return app_config
 
 

--- a/tests/resources/requests/test_requests_resources.py
+++ b/tests/resources/requests/test_requests_resources.py
@@ -139,7 +139,7 @@ def test_simple_request_flow(app, client_logged_as, headers, example_request):
         "id": id_,
         "number": example_request.number,
         "title": "Foo bar",
-        "type": "invenio-requests.request",
+        "type": "default-request",
         "created_by": {"user": "1"},
         "receiver": {"user": "2"},
         "topic": None,


### PR DESCRIPTION
since the default request type is only meant to be an example request type (and a good basis for custom request types), we do not actually want to register it during runtime