### PR TITLE
api: only have get_record resolve requests by id

### DIFF
--- a/invenio_requests/records/api.py
+++ b/invenio_requests/records/api.py
@@ -95,38 +95,6 @@ class Request(Record):
     is_expired = ExpiredStateCalculatedField("expires_at")
     """Whether or not the request is already expired."""
 
-    @classmethod
-    def get_record(cls, id_, with_deleted=False):
-        """Retrieve the request by id.
-
-        :param id_: The record's number or internal ID.
-        :param with_deleted: If `True`, then it includes deleted requests.
-        :returns: The :class:`Request` instance.
-        """
-        # note: in case of concurrency errors, `with db.session.no_autoflush` might help
-        try:
-            query = cls.model_cls.query.filter_by(number=str(id_))
-            if not with_deleted:
-                query = query.filter(cls.model_cls.is_deleted != True)  # noqa
-
-            model = query.one()
-
-        except (MultipleResultsFound, NoResultFound):
-            # either no results or ambiguous results
-            # (e.g. if number is None)
-            # NOTE: if 'id_' is None, this will return None!
-            query = cls.model_cls.query.filter_by(id=id_)
-            if not with_deleted:
-                query = query.filter(cls.model_cls.is_deleted != True)  # noqa
-
-            model = query.one()
-
-        if model is None:
-            # TODO maybe some kind of `NullRequest`?
-            return None
-
-        return cls(model.data, model=model)
-
 
 class RequestEventType(Enum):
     """Request Event type enum."""

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -57,7 +57,7 @@ def submit_request(create_request, requests_service):
     def _submit_request(identity, data=None):
         """Create and submit a request."""
         request = create_request(identity)
-        id_ = request.number
+        id_ = request.id
         data = data or {
             "payload": {
                 "content": "Can I belong to the community?",

--- a/tests/services/events/test_request_events_service.py
+++ b/tests/services/events/test_request_events_service.py
@@ -21,7 +21,7 @@ from invenio_requests.records.api import RequestEvent, RequestEventType
 
 def test_schemas(app, events_service_data, example_request):
     events_service = current_requests.request_events_service
-    request_id = example_request.number
+    request_id = example_request.id
     events_service_data["type"] = "INVALID"
 
     with pytest.raises(ValidationError):
@@ -88,7 +88,7 @@ def test_delete_non_comment(
         events_service_data, example_request, request_events_service):
     # Deleting a regular comment empties content and changes type (tested above)
     # Deleting an accept/decline/cancel event removes them
-    request_id = example_request.number
+    request_id = example_request.id
     del events_service_data["payload"]
 
     for typ in (t for t in RequestEventType if t != RequestEventType.COMMENT):
@@ -107,7 +107,7 @@ def test_delete_non_comment(
 def test_update_keeps_type(identity_simple, events_service_data, example_request):
     # The `update`` service method can't be used to change the type
     events_service = current_requests.request_events_service
-    request_id = example_request.number
+    request_id = example_request.id
     # event type is COMMENT by default
     item = events_service.create(identity_simple, request_id, events_service_data)
     comment_id = item.id


### PR DESCRIPTION
closes #74 

* actually, it is always the request ID that's used for external interfaces to interact with requests, and not the number
* thus, there was no real benefit in having Request.get_record resolve by either ID or number
* this only opened up the possibility of having one request's number shadow another request's ID and thus, potential issues