### PR TITLE
service: simplify permission lookup for actions

### DIFF
--- a/invenio_requests/services/requests/service.py
+++ b/invenio_requests/services/requests/service.py
@@ -30,23 +30,6 @@ from .links import RequestLinksTemplate
 class RequestsService(RecordService):
     """Requests service."""
 
-    def check_permission(self, identity, action_name, from_action=False, **kwargs):
-        """Check a permission against the identity."""
-        if from_action and "request" in kwargs:
-            # if we're checking permissions for a request action, we try to construct
-            # the permission name from the request action's name
-            type_id = kwargs["request"].type.type_id
-            custom_action_name = re.sub(r"[^a-zA-Z]", "_", f"{type_id}_{action_name}")
-
-            # use the custom action name if there's something registered
-            # otherwise use the default value
-            if hasattr(self.config.permission_policy_cls, custom_action_name):
-                action_name = custom_action_name
-            else:
-                action_name = f"action_{action_name}"
-
-        return self.permission_policy(action_name, **kwargs).allows(identity)
-
     @property
     def links_item_tpl(self):
         """Item links template."""
@@ -209,7 +192,8 @@ class RequestsService(RecordService):
         action_obj = RequestActions.get_action(request, action)
 
         # check permissions
-        self.require_permission(identity, action, request=request, from_action=True)
+        permission_name = f"action_{action}"
+        self.require_permission(identity, permission_name, request=request)
 
         # Check if the action *can* be executed (i.e. correct status etc.)
         if not action_obj.can_execute(identity):


### PR DESCRIPTION
* previously, the requests service would allow permissions for actions
  on each request type to be customized via special naming
* the events service however did not use the same lookup logic, so this
  could result in inconsistencies regarding permissions
* for now, we want to keep everything as simple as possible; we will
  extend the functionality once the need arises