### PR TITLE
permissions: disable requests when communities not enabled

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,8 @@ def app_config(app_config):
         "RECORDS_REFRESOLVER_STORE"
     ] = "invenio_jsonschemas.proxies.current_refresolver_store"
     app_config["REQUESTS_REGISTERED_TYPES"] = [DefaultRequestType()]
+    app_config["COMMUNITIES_ENABLED"] = True
+
     return app_config
 
 

--- a/tests/resources/requests/test_requests_resources.py
+++ b/tests/resources/requests/test_requests_resources.py
@@ -197,3 +197,18 @@ def test_simple_request_flow(app, client_logged_as, headers, example_request):
         }
     )
     assert_api_response(response, 200, expected_data)
+
+
+def test_disabled_endpoints(app, client_logged_as, headers, example_request):
+    app.config["COMMUNITIES_ENABLED"] = False
+    client = client_logged_as("user1@example.org")
+    id_ = str(example_request.id)
+
+    response = client.get(f"/requests/{id_}", headers=headers)
+    assert response.status_code == 403
+
+    response = client.post(f"/requests/{id_}/actions/submit", headers=headers)
+    assert response.status_code == 403  # id not found
+
+    response = client.post(f"/requests/{id_}/actions/cancel", headers=headers)
+    assert response.status_code == 403  # id not found


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1315

**Communities OFF**

<img width="1284" alt="Screenshot 2022-03-01 at 13 20 44" src="https://user-images.githubusercontent.com/6756943/156168177-91bb33ef-ea05-4e3d-89cc-c8be284a592c.png">

<img width="752" alt="Screenshot 2022-03-01 at 13 20 27" src="https://user-images.githubusercontent.com/6756943/156168186-fabac5b9-fa3c-420d-b60b-5a5f99a937d2.png">

**Communities ON**

<img width="1324" alt="Screenshot 2022-03-01 at 13 13 47" src="https://user-images.githubusercontent.com/6756943/156168190-93116aa2-6b2f-4571-a2df-c8d710a0bf08.png">

<img width="982" alt="Screenshot 2022-03-01 at 13 14 50" src="https://user-images.githubusercontent.com/6756943/156168187-a27a3cad-7ab5-402f-b433-58cd7e0075f8.png">

(missing tests)