### PR TITLE
Permissions: return permissions in request event calls

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvent/TimelineEvent.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvent/TimelineEvent.js
@@ -44,6 +44,9 @@ class TimelineEvent extends Component {
     const commentHasBeenDeleted = !event.payload;
     const commentCanBeDeleted = event.payload;
 
+    const canDelete = event.permissions.can_delete_comment;
+    const canUpdate = event.permissions.can_update_comment;
+
     return (
       <Overridable id="TimelineEvent.layout" event={event}>
         <Feed.Event>
@@ -68,15 +71,19 @@ class TimelineEvent extends Component {
                   </Feed.Summary>
                 </Grid.Column>
                 <Grid.Column width={1}>
-                  {commentCanBeDeleted && (
+                  {commentCanBeDeleted && (canDelete || canUpdate) && (
                     <Dropdown icon="ellipsis horizontal">
                       <Dropdown.Menu>
-                        <Dropdown.Item onClick={() => toggleEditMode()}>
-                          {i18next.t("Edit")}
-                        </Dropdown.Item>
-                        <Dropdown.Item onClick={() => deleteComment()}>
-                          {i18next.t("Delete")}
-                        </Dropdown.Item>
+                        {canUpdate && (
+                          <Dropdown.Item onClick={() => toggleEditMode()}>
+                            {i18next.t("Edit")}
+                          </Dropdown.Item>
+                        )}
+                        {canDelete && (
+                          <Dropdown.Item onClick={() => deleteComment()}>
+                            {i18next.t("Delete")}
+                          </Dropdown.Item>
+                        )}
                       </Dropdown.Menu>
                     </Dropdown>
                   )}

--- a/invenio_requests/services/events/service.py
+++ b/invenio_requests/services/events/service.py
@@ -11,15 +11,21 @@
 
 from elasticsearch_dsl import Q
 from invenio_access.permissions import system_process
-from invenio_records_resources.services import RecordService
+from invenio_records_resources.services import RecordService, ServiceSchemaWrapper
 from invenio_records_resources.services.base.links import LinksTemplate
 from invenio_records_resources.services.uow import RecordCommitOp, unit_of_work
 
 from ...records.api import RequestEventType
+from ..schemas import RequestEventDumpSchema
 
 
 class RequestEventsService(RecordService):
     """Request Events service."""
+
+    @property
+    def event_dump_schema(self):
+        """Schema for creation."""
+        return ServiceSchemaWrapper(self, schema=RequestEventDumpSchema)
 
     @unit_of_work()
     def create(self, identity, request_id, data, uow=None):
@@ -56,6 +62,7 @@ class RequestEventsService(RecordService):
             identity,
             event,
             links_tpl=self.links_item_tpl,
+            schema=self.event_dump_schema
         )
 
     def read(self, identity, id_):
@@ -70,6 +77,7 @@ class RequestEventsService(RecordService):
             identity,
             record,
             links_tpl=self.links_item_tpl,
+            schema=self.event_dump_schema
         )
 
     @unit_of_work()
@@ -101,6 +109,7 @@ class RequestEventsService(RecordService):
             identity,
             event,
             links_tpl=self.links_item_tpl,
+            schema=self.event_dump_schema
         )
 
     @unit_of_work()
@@ -156,6 +165,7 @@ class RequestEventsService(RecordService):
                 context={"request_id": request_id, "args": params},
             ),
             links_item_tpl=self.links_item_tpl,
+            schema=self.event_dump_schema
         )
 
     # Utilities

--- a/tests/resources/events/test_request_events_resources.py
+++ b/tests/resources/events/test_request_events_resources.py
@@ -55,6 +55,8 @@ def test_simple_comment_flow(
             "self": f"https://127.0.0.1:5000/api/requests/{request_id}/comments/{comment_id}",  # noqa
             # "report": ""  # TODO
         },
+        "permissions": {"can_update_comment": True,
+                        "can_delete_comment": True},
         "revision_id": 1,
         "type": RequestEventType.COMMENT.value,
     }
@@ -99,6 +101,8 @@ def test_simple_comment_flow(
             "self": f"https://127.0.0.1:5000/api/requests/{request_id}/comments/{comment_id}",  # noqa
             # "report": ""  # TODO
         },
+        "permissions": {"can_update_comment": True,
+                        "can_delete_comment": True},
         "revision_id": 2,
         "type": RequestEventType.COMMENT.value,
     }
@@ -119,6 +123,9 @@ def test_simple_comment_flow(
     response = client.get(f"/requests/{request_id}/timeline", headers=headers)
     assert 200 == response.status_code
     assert 2 == response.json["hits"]["total"]
+    # User 2 cannot updated or delete the comment created by user 1
+    expected_json_1["permissions"] = {"can_update_comment": False,
+                                      "can_delete_comment": False}
     assert_api_response_json(expected_json_1, response.json["hits"]["hits"][0])
     expected_json_3 = {
         "created_by": {"user": "2"},
@@ -126,6 +133,8 @@ def test_simple_comment_flow(
         "links": {
             "self": f"https://127.0.0.1:5000/api/requests/{request_id}/comments/{comment_id}",  # noqa
         },
+        "permissions": {"can_update_comment": True,
+                        "can_delete_comment": True},
         "revision_id": 4,
         "type": RequestEventType.REMOVED.value,
     }


### PR DESCRIPTION
Display edit/delete dropdown only for authorized users.
closes: inveniosoftware/invenio-requests#156

View of the user admin@test.ch
![Screenshot from 2022-03-29 15-56-23](https://user-images.githubusercontent.com/25476209/160795832-80211ea9-e48e-4729-9ab9-083fc11f08cb.png)

View of the user pablo@gmail.com
![Screenshot from 2022-03-29 15-56-30](https://user-images.githubusercontent.com/25476209/160795835-98f20eb4-1e90-47b6-b39f-bba545ddd411.png)
