### PR TITLE
request timeline: reload instead of refresh on action 

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/state/actions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/state/actions.js
@@ -29,7 +29,7 @@ export const updateRequest = (request) => {
 export const updateRequestAfterAction = (request) => {
   return async (dispatch, getState, config) => {
     dispatch(updateRequest(request));
-    dispatch(fetchTimeline());
+    window.location.reload();
   };
 };
 

--- a/tests/resources/events/test_request_events_resources.py
+++ b/tests/resources/events/test_request_events_resources.py
@@ -160,7 +160,7 @@ def test_timeline_links(
 
     expected_links = {
         # NOTE: Variations are covered in records-resources
-        "self": f"https://127.0.0.1:5000/api/requests/{request_id}/timeline?expand=False&page=1&refresh=False&size=25&sort=oldest"  # noqa
+        "self": f"https://127.0.0.1:5000/api/requests/{request_id}/timeline?page=1&size=25&sort=oldest"  # noqa
     }
     assert expected_links == search_record_links
 


### PR DESCRIPTION
Because the template can change after an action event it now reloads instead of just refreshing the timeline, also fixes an error on page load when the expanded object is not complete.

needed for https://github.com/inveniosoftware/invenio-app-rdm/pull/1538
partly closes https://github.com/inveniosoftware/invenio-requests/issues/187