### PR TITLE
request feed: fix avatar size and spacing on all screens

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/components/RequestsFeed.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/components/RequestsFeed.js
@@ -12,7 +12,7 @@ import { Container, Feed, Icon } from "semantic-ui-react";
 // Wrapper component for the custom styles being used inside the request events timeline
 // Enables centralizing the styles and abstracts it away from the template
 export const RequestsFeed = ({ children }) => (
-  <Container className="requests-feed-container">
+  <Container className="requests-feed-container ml-0-mobile mr-0-mobile">
     <Feed>{children}</Feed>
   </Container>
 );
@@ -30,7 +30,7 @@ export const RequestEventInnerContainer = ({ children, isEvent }) => (
 );
 
 export const RequestEventAvatarContainer = ({ src, ...uiProps }) => (
-  <div className="requests-avatar-container mt-10">
+  <div className="requests-avatar-container">
     <Image src={src} rounded avatar {...uiProps} />
   </div>
 );

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/TimelineFeed.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/TimelineFeed.js
@@ -49,7 +49,7 @@ class TimelineFeed extends Component {
       <Loader isLoading={loading}>
         <Error error={error}>
           <Overridable id="TimelineFeed.layout" {...this.props}>
-            <Container id="requests-timeline">
+            <Container id="requests-timeline" className="ml-0-mobile mr-0-mobile">
               <RequestsFeed>
                 {timeline.hits?.hits.map((event) => (
                   <TimelineCommentEventControlled

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
@@ -6,11 +6,11 @@
 
 import FormattedInputEditor from "../components/FormattedInputEditor";
 import React from "react";
-import { Image } from "react-invenio-forms";
 import { SaveButton } from "../components/Buttons";
-import { Grid, Message } from "semantic-ui-react";
+import { Container, Message } from "semantic-ui-react";
 import PropTypes from "prop-types";
 import { i18next } from "@translations/invenio_requests/i18next";
+import { RequestEventAvatarContainer } from "../components/RequestsFeed";
 
 const TimelineCommentEditor = ({
   isLoading,
@@ -23,19 +23,16 @@ const TimelineCommentEditor = ({
   return (
     <div className="timeline-comment-editor-container">
       {error && <Message negative>{error}</Message>}
-      <Grid>
-        <Grid.Column width={1}>
-          <Image src={userAvatar} alt="" aria-hidden={true} />
-        </Grid.Column>
-        <Grid.Column width={15}>
+      <div className="flex">
+        <RequestEventAvatarContainer src={userAvatar} className="tablet computer only rel-mr-1"/>
+        <Container fluid className="ml-0-mobile mr-0-mobile fluid-mobile">
           <FormattedInputEditor
             data={commentContent}
             onChange={(event, editor) => setCommentContent(editor.getData())}
             minHeight="7rem"
           />
-        </Grid.Column>
-      </Grid>
-
+        </Container>
+      </div>
       <div className="text-align-right rel-mt-1">
         <SaveButton
           icon="send"


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1738

Needs PR: https://github.com/inveniosoftware/invenio-app-rdm/pull/1758

## Differences from the mockups
The different scenarios (error message, pagination) did not work well with the proposed solution, so I removed the avatar completely from mobile, to give more space to the text box. The avatar on desktop is also slightly smaller than in the mockup, as I reused the `<RequestEventAvatarContainer />`, and was not sure why it should be bigger in the first place (was it intentional? If so, lmk.)

## Changes

- Removes avatar from mobile
- Fixes sizing bug for avatar on tablet
- Less space between the avatar and the text box on tablet and desktop

## Screenshots
![Screenshot 2022-06-17 at 10 19 48](https://user-images.githubusercontent.com/21052053/174304375-e0ea2f4a-5fb6-4eff-b91e-8cfdef689968.png)
![Screenshot 2022-06-17 at 10 19 40](https://user-images.githubusercontent.com/21052053/174304380-06139fd6-534f-4c46-92d5-d87230c6dc9c.png)
![Screenshot 2022-06-17 at 10 19 33](https://user-images.githubusercontent.com/21052053/174304381-1f53d774-ecc5-4e7b-a08c-a460a1f1fb7c.png)
![Screenshot 2022-06-17 at 10 18 58](https://user-images.githubusercontent.com/21052053/174304382-ef216bb9-f490-44f3-883b-1b68094e8dd0.png)
![Screenshot 2022-06-17 at 10 18 49](https://user-images.githubusercontent.com/21052053/174304384-433560bb-676d-4ffd-931f-fb69a106c382.png)
![Screenshot 2022-06-17 at 10 18 38](https://user-images.githubusercontent.com/21052053/174304386-05746a15-802e-4471-8fb2-6a0aaafdbd31.png)
![Screenshot 2022-06-17 at 10 17 41](https://user-images.githubusercontent.com/21052053/174304391-0ad9d24f-ecc1-4a0f-942d-40245e01c9f6.png)
![Screenshot 2022-06-17 at 10 17 30](https://user-images.githubusercontent.com/21052053/174304392-46ce8398-d90a-4149-87f6-8e6a218f91d3.png)
![Screenshot 2022-06-17 at 10 17 20](https://user-images.githubusercontent.com/21052053/174304394-a9897470-252a-4d04-a139-de4469861126.png)

