### PR TITLE
comment deletion: synchronize behaviour with backend

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/requestsAppInit.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/requestsAppInit.js
@@ -10,6 +10,7 @@ import { InvenioRequestsApp } from "./InvenioRequestsApp";
 import {
   TimelineAcceptEvent,
   TimelineCancelEvent,
+  TimelineCommentDeletionEvent,
   TimelineDeclineEvent,
   TimelineExpireEvent,
   TimelineUnknownEvent,
@@ -36,9 +37,7 @@ const request = JSON.parse(requestDetailsDiv.dataset.record);
 const defaultQueryParams = JSON.parse(
   requestDetailsDiv.dataset.defaultQueryConfig
 );
-const userAvatar = JSON.parse(
-  requestDetailsDiv.dataset.userAvatar
-);
+const userAvatar = JSON.parse(requestDetailsDiv.dataset.userAvatar);
 
 const overriddenComponents = {
   "TimelineEvent.layout.unknown": TimelineUnknownEvent,
@@ -46,6 +45,7 @@ const overriddenComponents = {
   "TimelineEvent.layout.accepted": TimelineAcceptEvent,
   "TimelineEvent.layout.expired": TimelineExpireEvent,
   "TimelineEvent.layout.cancelled": TimelineCancelEvent,
+  "TimelineEvent.layout.comment_deleted": TimelineCommentDeletionEvent,
   "RequestStatus.layout.submitted": SubmitStatus,
   "RequestStatus.layout.deleted": DeleteStatus,
   "RequestStatus.layout.accepted": AcceptStatus,

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/state/actions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/state/actions.js
@@ -85,7 +85,7 @@ export const setPage = (page) => {
       payload: page,
     });
 
-    dispatch(fetchTimeline());
+    await dispatch(fetchTimeline());
   };
 };
 

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/actions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/actions.js
@@ -80,6 +80,7 @@ export const submitComment = (content, format) => {
 };
 
 const _updatedState = (newComment, timelineState, shouldGoToNextPage) => {
+  // return timeline with new comment and pagination logic
   const timelineData = _cloneDeep(timelineState.data);
   const currentHits = timelineData.hits.hits;
 

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
@@ -52,8 +52,6 @@ class TimelineCommentEvent extends Component {
     const { commentContent } = this.state;
 
     const commentHasBeenEdited = event?.revision_id > 1 && event?.payload;
-    const commentHasBeenDeleted = !event?.payload;
-    const commentCanBeDeleted = event?.payload;
 
     const canDelete = event?.permissions?.can_delete_comment;
     const canUpdate = event?.permissions?.can_update_comment;
@@ -86,7 +84,7 @@ class TimelineCommentEvent extends Component {
             {userAvatar}
             <RequestsFeed.Event>
               <Feed.Content>
-                {commentCanBeDeleted && (canDelete || canUpdate) && (
+                {(canDelete || canUpdate) && (
                   <Dropdown
                     icon="ellipsis horizontal"
                     className="right-floated"
@@ -109,7 +107,8 @@ class TimelineCommentEvent extends Component {
                 <Feed.Summary>
                   <b>{userName}</b>
                   <Feed.Date>
-                    {i18next.t("commented")} {timestampToRelativeTime(event.created)}
+                    {i18next.t("commented")}{" "}
+                    {timestampToRelativeTime(event.created)}
                   </Feed.Date>
                 </Feed.Summary>
 
@@ -141,11 +140,8 @@ class TimelineCommentEvent extends Component {
                     </Container>
                   )}
                 </Feed.Extra>
-                {(commentHasBeenEdited || commentHasBeenDeleted) && (
-                  <Feed.Meta>
-                    {commentHasBeenEdited && i18next.t("Edited")}
-                    {commentHasBeenDeleted && i18next.t("Deleted")}
-                  </Feed.Meta>
+                {commentHasBeenEdited && (
+                  <Feed.Meta>{i18next.t("Edited")}</Feed.Meta>
                 )}
               </Feed.Content>
             </RequestsFeed.Event>

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/timelineActionEvents.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/timelineActionEvents.js
@@ -52,3 +52,12 @@ export const TimelineUnknownEvent = ({ event }) => (
     eventContent={i18next.t("unknown event")}
   />
 );
+
+export const TimelineCommentDeletionEvent = ({ event }) => (
+  <TimelineActionEvent
+    iconName="erase"
+    iconColor="grey"
+    event={event}
+    eventContent={i18next.t("deleted a comment")}
+  />
+);

--- a/tests/services/events/test_request_events_service.py
+++ b/tests/services/events/test_request_events_service.py
@@ -70,9 +70,6 @@ def test_simple_flow(
     deleted_item = request_events_service.delete(identity_simple, id_)
     assert deleted_item is True
     RequestEvent.index.refresh()
-    # assert that the comment was deleted and cannot be read anymore
-    with pytest.raises(NoResultFound):
-        request_events_service.read(identity_simple, id_)
     # find the newly created deleted event
     res = request_events_service.search(identity_simple, request_id, sort="newest")
     deleted = list(res.hits)[0]
@@ -80,7 +77,6 @@ def test_simple_flow(
     assert LogEventType.type_id == deleted["type"]
     assert "comment_deleted" == deleted["payload"]["event"]
     assert "deleted a comment" == deleted["payload"]["content"]
-
     # Search (batch read) events
     # Let's create a separate request with comment and make sure search is isolated
     data = copy.deepcopy(comment)


### PR DESCRIPTION
When the user deletes a comment it will now be replaced by a deletion logEvent, in place of the deleted comment.
![Screenshot from 2022-06-21 10-15-29](https://user-images.githubusercontent.com/55200060/177117972-4aaadb6a-97a0-43b4-9252-42ad121bde02.png)



closes https://github.com/inveniosoftware/invenio-requests/issues/251
