### PR TITLE
request action modal: reduce default button size

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActionModalTrigger.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActionModalTrigger.js
@@ -58,7 +58,7 @@ RequestActionModalTrigger.propTypes = {
 };
 
 RequestActionModalTrigger.defaultProps = {
-  size: "medium",
+  size: "small",
   device: "",
 };
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-requests/issues/268

Related to https://github.com/inveniosoftware/invenio-app-rdm/pull/1846

- Reduces default size of request action buttons, to reduce over crowding/clutter in the ui