### PR TITLE
Add `can_create_comment` permission

### DIFF
--- a/invenio_requests/services/events/service.py
+++ b/invenio_requests/services/events/service.py
@@ -47,8 +47,7 @@ class RequestEventsService(RecordService):
         :param dict data: Input data according to the data schema.
         """
         request = self._get_request(request_id)
-        # If you can read the request you can create events for the request.
-        self.require_permission(identity, "read", request=request)
+        self.require_permission(identity, "create_comment", request=request)
 
         # Validate data (if there are errors, .load() raises)
         schema = self._wrap_schema(event_type.marshmallow_schema())

--- a/invenio_requests/services/permissions.py
+++ b/invenio_requests/services/permissions.py
@@ -80,6 +80,8 @@ class PermissionPolicy(RecordPermissionPolicy):
         Commenter(),
         SystemProcess(),
     ]
+    # If you can read the request you can create events for the request.
+    can_create_comment = can_read
 
     # Needed by the search events permission because a permission_action must
     # be provided to create_search(), but the event search is already protected


### PR DESCRIPTION
This decouples the permission for creating comments from reading requests, in order to prepare for adding a read-only mode in the repository