### PR TITLE
migrate: flask_babelex replaced by invenio_i18n

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,14 @@
 Changes
 =======
 
+Version 1.1.0 (released 2023-03-02)
+
+- remove deprecated flask-babelex imports
+- upgrade invenio-theme, invenio-records-resources, invenio-users-resources
+
 Version 1.0.5 (released 2022-12-01)
 
 - Add identity to links template expand method.
-
 
 Version 1.0.4 (released 2022-11-25)
 

--- a/invenio_requests/__init__.py
+++ b/invenio_requests/__init__.py
@@ -19,7 +19,7 @@ from .proxies import (
     current_requests_service,
 )
 
-__version__ = "1.0.5"
+__version__ = "1.1.0"
 
 __all__ = (
     "__version__",

--- a/invenio_requests/services/events/service.py
+++ b/invenio_requests/services/events/service.py
@@ -3,14 +3,15 @@
 # Copyright (C) 2021-2022 CERN.
 # Copyright (C) 2021-2022 Northwestern University.
 # Copyright (C) 2021-2022 TU Wien.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Requests is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """RequestEvents Service."""
 
-from flask_babelex import _
 from invenio_access.permissions import system_process
+from invenio_i18n import _
 from invenio_records_resources.services import RecordService, ServiceSchemaWrapper
 from invenio_records_resources.services.base.links import LinksTemplate
 from invenio_records_resources.services.uow import (

--- a/invenio_requests/services/requests/facets.py
+++ b/invenio_requests/services/requests/facets.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Facet definitions."""
 
-from flask_babelex import gettext as _
+from invenio_i18n import gettext as _
 from invenio_records_resources.services.records.facets import TermsFacet
 
 type = TermsFacet(

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,9 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-records-resources>=1.0.0,<2.0.0
-    invenio-theme>=1.3.11,<2.0.0
-    invenio-users-resources>=1.0.0,<2.0.0
+    invenio-records-resources>=1.1.0,<2.0.0
+    invenio-theme>=2.0.0,<3.0.0
+    invenio-users-resources>=1.1.0,<2.0.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
- NOTE: Flask-Security-Invenio invenio-accounts invenio-admin invenio-files-rest invenio-i18n invenio-oauthclient invenio-pidstore invenio-records invenio-records-resources invenio-theme invenio-users-resources have to be released first