### PR TITLE
notifications: add comment request event notification

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,7 +25,7 @@ recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
-recursive-include invenio_requests *.html
+recursive-include invenio_requests *.html *.jinja
 recursive-include invenio_requests *.js
 recursive-include invenio_requests *.json
 recursive-include invenio_requests *.less

--- a/invenio_requests/notifications/__init__.py
+++ b/invenio_requests/notifications/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# Invenio-Requests is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Notification related files for request purposes."""

--- a/invenio_requests/notifications/builders.py
+++ b/invenio_requests/notifications/builders.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# Invenio-Requests is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Notification builders."""
+
+from invenio_notifications.models import Notification
+from invenio_notifications.registry import EntityResolverRegistry
+from invenio_notifications.services.builders import NotificationBuilder
+from invenio_notifications.services.generators import EntityResolve, UserEmailBackend
+from invenio_users_resources.notifications.filters import UserPreferencesRecipientFilter
+
+from invenio_requests.notifications.filters import UserRecipientFilter
+
+from .generators import RequestParticipantsRecipient
+
+
+class CommentRequestEventCreateNotificationBuilder(NotificationBuilder):
+    """Notification builder for comment request event creation."""
+
+    type = "comment-request-event.create"
+
+    @classmethod
+    def build(cls, request, request_event):
+        """Build notification with context."""
+        return Notification(
+            type=cls.type,
+            context={
+                "request": EntityResolverRegistry.reference_entity(request),
+                "request_event": EntityResolverRegistry.reference_entity(request_event),
+            },
+        )
+
+    context = [
+        EntityResolve(key="request"),
+        EntityResolve(key="request.created_by"),
+        EntityResolve(key="request.receiver"),
+        EntityResolve(key="request_event"),
+        EntityResolve(key="request_event.created_by"),
+    ]
+
+    recipients = [
+        RequestParticipantsRecipient(key="request"),
+    ]
+
+    recipient_filters = [
+        # do not send notification to user creating the comment
+        UserRecipientFilter(key="request_event.created_by"),
+        UserPreferencesRecipientFilter(),
+    ]
+
+    recipient_backends = [
+        UserEmailBackend(),
+    ]

--- a/invenio_requests/notifications/filters.py
+++ b/invenio_requests/notifications/filters.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# Invenio-Requests is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Recipient filters for notifications."""
+
+from invenio_notifications.services.filters import RecipientFilter
+from invenio_records.dictutils import dict_lookup
+
+
+class UserRecipientFilter(RecipientFilter):
+    """Recipient filter based on user."""
+
+    def __init__(self, key):
+        """Initialize with key for user lookup."""
+        super().__init__()
+        self._key = key
+
+    def __call__(self, notification, recipients):
+        """Filter recipients."""
+        user = dict_lookup(notification.context, self._key)
+        # lookup (non) expanded user field
+        user_id = user.get("user") or user.get("id")
+
+        if user_id in recipients:
+            del recipients[user_id]
+
+        return recipients

--- a/invenio_requests/notifications/generators.py
+++ b/invenio_requests/notifications/generators.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 Graz University of Technology.
+#
+# Invenio-Requests is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Notification generators."""
+
+from invenio_access.permissions import system_identity
+from invenio_notifications.models import Recipient
+from invenio_notifications.services.generators import RecipientGenerator
+from invenio_records.dictutils import dict_lookup
+from invenio_search.engine import dsl
+from invenio_users_resources.proxies import current_users_service
+
+from ..proxies import current_events_service
+
+
+class RequestParticipantsRecipient(RecipientGenerator):
+    """Recipient generator based on request and it's events."""
+
+    def __init__(self, key):
+        """Ctor."""
+        self.key = key
+
+    def _get_user_id(self, request_field):
+        """Checking if entities are users for (non)-expanded requests."""
+        # non expanded looks like {"user": "1"}
+        non_expanded_id = request_field.get("user")
+        # expanded looks like {"id": "1", "profile": {"full_name": "A user"}, ... }
+        expanded_id = request_field["id"] if request_field.get("profile") else None
+        return non_expanded_id or expanded_id
+
+    def __call__(self, notification, recipients: dict):
+        """Fetch users involved in request and add as recipients."""
+        request = dict_lookup(notification.context, self.key)
+
+        # checking if entities are users. If not, we will not add them.
+        # TODO: add support for other entities? (e.g. groups)
+
+        created_by_user_id = self._get_user_id(request["created_by"])
+        receiver_user_id = self._get_user_id(request["receiver"])
+
+        user_ids = set()
+        if created_by_user_id:
+            user_ids.add(created_by_user_id)
+
+        if receiver_user_id:
+            user_ids.add(receiver_user_id)
+
+        # fetching all request events to get involved users
+        request_events = current_events_service.scan(
+            identity=system_identity,
+            extra_filter=dsl.Q("term", request_id=request["id"]),
+        )
+
+        user_ids.update(
+            {
+                re["created_by"]["user"]
+                for re in request_events
+                if re["created_by"].get("user")
+            }
+        )
+
+        filter_ = dsl.Q("terms", **{"id": list(user_ids)})
+        users = current_users_service.scan(system_identity, extra_filter=filter_)
+        for u in users:
+            recipients[u["id"]] = Recipient(data=u)
+        return recipients

--- a/invenio_requests/templates/semantic-ui/invenio_notifications/comment-request-event.create.jinja
+++ b/invenio_requests/templates/semantic-ui/invenio_notifications/comment-request-event.create.jinja
@@ -1,0 +1,44 @@
+{% set invenio_request = notification.context.request %}
+{% set invenio_request_event = notification.context.request_event %}
+
+{% set event_creator_name = invenio_request_event.created_by.username %}
+{% set request_id = invenio_request.id %}
+{% set request_event_content = invenio_request_event.payload.content | safe %}
+{% set request_title = invenio_request.title | safe %}
+
+{# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
+{% set request_link = "{ui}/me/requests/{id}".format(
+    ui=config.SITE_UI_URL, id=request_id
+    )
+%}
+
+{%- block subject -%}
+{{ _("New comment on '{request_title}'").format(request_title=request_title) }}
+{%- endblock subject -%}
+
+{%- block html_body -%}
+<p>
+    {{ _("'{user_name}' commented on '{request_title}'").format(user_name=event_creator_name, request_title=request_title) }}.
+</p>
+{{ request_event_content }}
+
+<a href="{{ request_link }}" class="button"> {{ _("Check out the request") }}</a>
+{%- endblock html_body %}
+
+{%- block plain_body -%}
+{{ _("'{user_name}' commented on '{request_title}'").format(user_name=event_creator_name, request_title=request_title) }}.
+
+{{ request_event_content }}
+
+{{ _("Check out the request: {request_link}").format(request_link=request_link) }}
+
+{%- endblock plain_body %}
+
+{# Markdown for Slack/Mattermost/chat #}
+{%- block md_body -%}
+{{ _("*{user_name}* commented on *{request_title}*").format(user_name=event_creator_name, request_title=request_title) }}.
+
+{{ request_event_content }}
+
+[{{_("Check out the request")}}]({{request_link}})
+{%- endblock md_body %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ invenio_base.blueprints =
     invenio_requests_ext = invenio_requests.views:blueprint
 invenio_base.api_blueprints =
     invenio_requests = invenio_requests.views:create_requests_bp
+    invenio_requests_ui = invenio_requests.views:create_ui_blueprint
     invenio_request_events = invenio_requests.views:create_request_events_bp
     invenio_requests_ext = invenio_requests.views:blueprint
 invenio_celery.tasks =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2021 Northwestern University.
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Requests is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -40,8 +41,46 @@ from invenio_access.permissions import superuser_access
 from invenio_accounts.models import Role
 from invenio_accounts.testutils import login_user_via_session
 from invenio_app.factory import create_api as _create_api
+from invenio_notifications.backends import EmailNotificationBackend
+from invenio_notifications.services.builders import NotificationBuilder
+from invenio_records_resources.references.entity_resolvers import ServiceResultResolver
+from invenio_users_resources.proxies import current_users_service
+from invenio_users_resources.records import UserAggregate
+from invenio_users_resources.services.schemas import (
+    NotificationPreferences,
+    UserPreferencesSchema,
+    UserSchema,
+)
+from marshmallow import fields
 
 from invenio_requests.customizations import CommentEventType, LogEventType, RequestType
+from invenio_requests.notifications.builders import (
+    CommentRequestEventCreateNotificationBuilder,
+)
+
+
+class UserPreferencesNotificationsSchema(UserPreferencesSchema):
+    """Schema extending preferences with notification preferences for model validation."""
+
+    notifications = fields.Nested(NotificationPreferences)
+
+
+class NotificationsUserSchema(UserSchema):
+    """Schema for dumping a user with preferences including notifications."""
+
+    preferences = fields.Nested(UserPreferencesNotificationsSchema)
+
+
+class DummyNotificationBuilder(NotificationBuilder):
+    """Dummy builder class to do nothing.
+
+    Specific test cases should override their respective builder to test functionality.
+    """
+
+    @classmethod
+    def build(cls, **kwargs):
+        """Build notification based on type and additional context."""
+        return {}
 
 
 @pytest.fixture(scope="module")
@@ -82,7 +121,35 @@ def app_config(app_config):
         "RECORDS_REFRESOLVER_STORE"
     ] = "invenio_jsonschemas.proxies.current_refresolver_store"
     app_config["REQUESTS_REGISTERED_TYPES"] = [RequestType()]
-    app_config["REQUESTS_REGISTERED_EVENT_TYPES"] = [LogEventType(), CommentEventType()]
+    app_config["REQUESTS_REGISTERED_EVENT_TYPES"] = [
+        LogEventType(),
+        CommentEventType(),
+    ]
+
+    app_config["MAIL_DEFAULT_SENDER"] = "test@inveniosoftware.org"
+
+    # Specifying backend for notifications. Only used in specific testcases.
+    app_config["NOTIFICATIONS_BACKENDS"] = {
+        EmailNotificationBackend.id: EmailNotificationBackend(),
+    }
+
+    # Specifying dummy builders to avoid raising errors for most tests. Extend as needed.
+    app_config["NOTIFICATIONS_BUILDERS"] = {
+        CommentRequestEventCreateNotificationBuilder.type: DummyNotificationBuilder,
+    }
+
+    # Specifying default resolvers. Will only be used in specific test cases.
+    app_config["NOTIFICATIONS_ENTITY_RESOLVERS"] = [
+        ServiceResultResolver(service_id="users", type_key="user"),
+        ServiceResultResolver(service_id="requests", type_key="request"),
+        ServiceResultResolver(service_id="request_events", type_key="request_event"),
+    ]
+
+    # Extending preferences schemas, to include notification preferences. Should not matter for most test cases
+    app_config[
+        "ACCOUNTS_USER_PREFERENCES_SCHEMA"
+    ] = UserPreferencesNotificationsSchema()
+    app_config["USERS_RESOURCES_SERVICE_SCHEMA"] = NotificationsUserSchema
     return app_config
 
 
@@ -92,24 +159,16 @@ def create_app(instance_path):
     return _create_api
 
 
-@pytest.fixture(scope="module")
-def identity_simple():
+@pytest.fixture()
+def identity_simple(user1):
     """Simple identity fixture."""
-    i = Identity(1)
-    i.provides.add(UserNeed(1))
-    i.provides.add(Need(method="system_role", value="any_user"))
-    i.provides.add(Need(method="system_role", value="authenticated_user"))
-    return i
+    return user1.identity
 
 
-@pytest.fixture(scope="module")
-def identity_simple_2():
+@pytest.fixture()
+def identity_simple_2(user2):
     """Another simple identity fixture."""
-    i = Identity(2)
-    i.provides.add(UserNeed(2))
-    i.provides.add(Need(method="system_role", value="any_user"))
-    i.provides.add(Need(method="system_role", value="authenticated_user"))
-    return i
+    return user2.identity
 
 
 @pytest.fixture(scope="module")
@@ -139,70 +198,123 @@ def headers():
 
 
 @pytest.fixture(scope="module")
-def users(app):
-    """Create example users."""
-    # This is a convenient way to get a handle on db that, as opposed to the
-    # fixture, won't cause a DB rollback after the test is run in order
-    # to help with test performance (creating users is a module -if not higher-
-    # concern)
-    from invenio_db import db
-
-    with db.session.begin_nested():
-        datastore = app.extensions["security"].datastore
-
-        su_role = Role(name="superuser-access")
-        db.session.add(su_role)
-
-        su_action_role = ActionRoles.create(action=superuser_access, role=su_role)
-        db.session.add(su_action_role)
-
-        user1 = datastore.create_user(
-            email="user1@example.org", password=hash_password("password"), active=True
+def users(UserFixture, app, database):
+    """Users."""
+    users = {}
+    for r in ["user1", "user2", "user3"]:
+        u = UserFixture(
+            email=f"{r}@example.org",
+            password=r,
+            user_profile={
+                "full_name": r,
+                "affiliations": "CERN",
+            },
+            preferences={
+                "visibility": "public",
+                "email_visibility": "restricted",
+                "notifications": {
+                    "enabled": True,
+                },
+            },
+            active=True,
+            confirmed=True,
         )
-        user2 = datastore.create_user(
-            email="user2@example.org", password=hash_password("password"), active=True
-        )
-        admin = datastore.create_user(
-            email="admin@example.org", password=hash_password("password"), active=True
-        )
-        admin.roles.append(su_role)
-
-    db.session.commit()
-    return [user1, user2, admin]
+        u.create(app, database)
+        users[r] = u
+    # when using `database` fixture (and not `db`), commit the creation of the
+    # user because its implementation uses a nested session instead
+    database.session.commit()
+    current_users_service.indexer.process_bulk_queue()
+    current_users_service.record_cls.index.refresh()
+    return users
 
 
 @pytest.fixture()
-def example_user(users):
-    """Create example user."""
-    return users[0]
+def user1(users):
+    """User 1 for requests."""
+    return users["user1"]
 
 
 @pytest.fixture()
-def example_request(identity_simple, request_record_input_data, users):
+def user2(users):
+    """User 2 for requests."""
+    return users["user2"]
+
+
+@pytest.fixture(scope="module")
+def superuser(UserFixture, app, database, superuser_role):
+    """Admin user for requests."""
+    u = UserFixture(
+        email="admin@example.org",
+        password="admin",
+        user_profile={
+            "full_name": "admin",
+            "affiliations": "CERN",
+        },
+        preferences={
+            "visibility": "public",
+            "email_visibility": "restricted",
+            "notifications": {
+                "enabled": True,
+            },
+        },
+        active=True,
+        confirmed=True,
+    )
+    u.create(app, database)
+    u.user.roles.append(superuser_role.role)
+
+    database.session.commit()
+    UserAggregate.index.refresh()
+    return u
+
+
+@pytest.fixture(scope="module")
+def superuser_role(database):
+    """Store 1 role with 'superuser-access' ActionNeed.
+
+    WHY: This is needed because expansion of ActionNeed is
+         done on the basis of a User/Role being associated with that Need.
+         If no User/Role is associated with that Need (in the DB), the
+         permission is expanded to an empty list.
+    """
+    role = Role(id="superuser-access", name="superuser-access")
+    database.session.add(role)
+
+    action_role = ActionRoles.create(action=superuser_access, role=role)
+    database.session.add(action_role)
+
+    database.session.commit()
+
+    return action_role
+
+
+@pytest.fixture()
+def example_request(identity_simple, request_record_input_data, user1, user2):
     """Example record."""
     # Need to use the service to get the id I guess...
     from invenio_requests.proxies import current_requests
-
-    user1, user2 = users[0], users[1]
 
     requests_service = current_requests.requests_service
     item = requests_service.create(
         identity_simple,
         request_record_input_data,
         RequestType,
-        receiver=user2,
-        creator=user1,
+        receiver=user2.user,
+        creator=user1.user,
     )
     return item._request
 
 
 @pytest.fixture()
-def client_logged_as(client, users):
+def client_logged_as(client, users, superuser):
     """Logs in a user to the client."""
 
     def log_user(user_email):
         """Log the user."""
-        user = next((u for u in users if u.email == user_email), None)
+        available_users = list(users.values()) + [superuser]
+
+        user = next((u.user for u in available_users if u.email == user_email), None)
         login_user(user, remember=True)
         login_user_via_session(client, email=user_email)
         return client

--- a/tests/customizations/test_request_types.py
+++ b/tests/customizations/test_request_types.py
@@ -135,14 +135,14 @@ def test_customized_reference_types(customized_app):
     assert errors
 
 
-def test_customized_request_actions(customized_app, users):
+def test_customized_request_actions(customized_app, user1):
     """Test if the action customization mechanism works."""
     service = customized_app.extensions["invenio-requests"].requests_service
     request = service.create(
         system_identity,
         {},
         CustomizedReferenceRequestType,
-        receiver=users[0],
+        receiver=user1.user,
         creator=None,
     )
 

--- a/tests/resources/requests/conftest.py
+++ b/tests/resources/requests/conftest.py
@@ -16,9 +16,9 @@ from invenio_requests.records.api import RequestEventFormat
 
 
 @pytest.fixture()
-def request_resource_data(users):
+def request_resource_data(user1):
     """Example data for sending to the REST API."""
-    user = users[0]
+    user = user1.user
 
     return {
         "title": "Example Request",
@@ -31,7 +31,7 @@ def example_requests(app, users):
     """A few example requests."""
     svc = app.extensions["invenio-requests"].requests_service
 
-    u1, u2, u3 = users
+    u1, u2, u3 = [u.user for u in users.values()]
     req1 = svc.create(
         sys_id, {"title": "first"}, RequestType, receiver=u1, creator=u3
     )._obj

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -29,13 +29,13 @@ def request_events_service(app):
 
 
 @pytest.fixture()
-def create_request(users, request_record_input_data, requests_service):
+def create_request(user2, request_record_input_data, requests_service):
     """Request Factory fixture."""
 
     def _create_request(identity, input_data=None, receiver=None, **kwargs):
         """Create a request."""
         input_data = input_data or request_record_input_data
-        receiver = receiver or users[1]
+        receiver = receiver or user2.user
         # Need to use the service to get the id
         item = requests_service.create(
             identity, input_data, RequestType, receiver=receiver, **kwargs

--- a/tests/services/events/test_request_events_service.py
+++ b/tests/services/events/test_request_events_service.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Requests is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,13 +10,18 @@
 
 """Service tests."""
 import copy
+from unittest.mock import MagicMock
 
 import pytest
 from invenio_access.permissions import system_identity
+from invenio_notifications.proxies import current_notifications_manager
 from sqlalchemy.exc import NoResultFound
 
 from invenio_requests.customizations import CommentEventType, LogEventType
 from invenio_requests.customizations.event_types import EventType
+from invenio_requests.notifications.builders import (
+    CommentRequestEventCreateNotificationBuilder,
+)
 from invenio_requests.proxies import current_event_type_registry, current_requests
 from invenio_requests.records.api import RequestEvent
 
@@ -168,3 +174,95 @@ def test_events_are_searchable(
     search_log_event = list(searched_items.hits)[1]
     assert search_log_event["payload"] == log_event["payload"]
     assert search_log_event["type"] == LogEventType.type_id
+
+
+#
+# invenio-notification testcases
+#
+def test_comment_request_event_notification(
+    app,
+    events_service_data,
+    submit_request,
+    request_events_service,
+    user1,
+    user2,
+    superuser,
+    monkeypatch,
+):
+    """Test notifcation being sent on request comment create."""
+
+    original_builder = CommentRequestEventCreateNotificationBuilder
+
+    # mock build to observe calls
+    mock_build = MagicMock()
+    mock_build.side_effect = original_builder.build
+    monkeypatch.setattr(original_builder, "build", mock_build)
+    # setting specific builder for test case
+    monkeypatch.setattr(
+        current_notifications_manager,
+        "builders",
+        {
+            **current_notifications_manager.builders,
+            original_builder.type: original_builder,
+        },
+    )
+    assert not mock_build.called
+
+    mail = app.extensions.get("mail")
+    assert mail
+
+    request = submit_request(user2.identity, receiver=user1.user)
+    request_id = request.id
+    comment = events_service_data["comment"]
+
+    with mail.record_messages() as outbox:
+        # Create a comment as creator
+        request_events_service.create(
+            user2.identity, request_id, dict(**comment), CommentEventType
+        )
+
+        # check notification is build on create
+        assert mock_build.called
+
+        # only request receiver should get notification
+        assert len(outbox) == 1
+        assert user1.email in outbox[0].recipients
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(request_id) in html
+        assert comment["payload"]["content"] in html
+
+    with mail.record_messages() as outbox:
+        # Create a comment as receiver
+        request_events_service.create(
+            user1.identity, request_id, dict(**comment), CommentEventType
+        )
+
+        # check notification is build on create
+        assert mock_build.called
+
+        # only request creator should get notification
+        assert len(outbox) == 1
+        assert user2.email in outbox[0].recipients
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(request_id) in html
+        assert comment["payload"]["content"] in html
+
+    with mail.record_messages() as outbox:
+        # Create a comment as superuser
+        request_events_service.create(
+            superuser.identity, request_id, dict(**comment), CommentEventType
+        )
+
+        # check notification is build on create
+        assert mock_build.called
+
+        # request creator and receiver should get notifications
+        assert len(outbox) == 2
+        assert user1.email in outbox[0].recipients
+        assert user2.email in outbox[1].recipients
+        html = outbox[0].html
+        # TODO: update to `req["links"]["self_html"]` when addressing https://github.com/inveniosoftware/invenio-rdm-records/issues/1327
+        assert "/me/requests/{}".format(request_id) in html
+        assert comment["payload"]["content"] in html

--- a/tests/services/requests/test_request_search_permissions.py
+++ b/tests/services/requests/test_request_search_permissions.py
@@ -34,7 +34,7 @@ def test_relevant_identities_can_search_requests(
     users,
     create_request,
 ):
-    u1, u2, u3 = users
+    u1, u2, u3 = [u.user for u in users.values()]
     u1_request = create_request(identity_simple, receiver=u2, creator=u1)
     create_request(identity_simple, receiver=u3, creator=u1)
     request = create_request(identity_simple_2, receiver=u3, creator=u2)

--- a/tests/services/requests/test_requests_service.py
+++ b/tests/services/requests/test_requests_service.py
@@ -124,12 +124,12 @@ def test_search_user_requests(
     app,
     identity_simple,
     identity_simple_2,
-    users,
+    user1,
     submit_request,
     requests_service,
     create_request,
 ):
-    request = submit_request(identity_simple, receiver=users[2])
+    request = submit_request(identity_simple, receiver=user1.user)
     request_id = request.id
     Request.index.refresh()
 


### PR DESCRIPTION
A new recipient generator takes care of fetching all users participating in a request. A notification operation is only triggered if the request event is a comment.

:heart: Thank you for your contribution!

### Description

closes #304 

Add notification to be sent when creating a comment on a request. This will trigger on every request comment (e.g. community invitation, community submission). Recipients will be users who have taken part in the request so far, without the user creating the comment.

The requests package does not know about communities, so we can not use the community member recipient generator to fetch certain members (e.g. owners, managers). This can be overridden in `app-rdm` if required.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
