### PR TITLE
access request: update guest request payload

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/InvenioRequestsApp.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/InvenioRequestsApp.js
@@ -38,12 +38,12 @@ export class InvenioRequestsApp extends Component {
   }
 
   render() {
-    const { overriddenCmps, userAvatar } = this.props;
+    const { overriddenCmps, userAvatar, permissions } = this.props;
 
     return (
       <OverridableContext.Provider value={overriddenCmps}>
         <Provider store={this.store}>
-          <Request userAvatar={userAvatar} />
+          <Request userAvatar={userAvatar} permissions={permissions}/>
         </Provider>
       </OverridableContext.Provider>
     );
@@ -57,6 +57,7 @@ InvenioRequestsApp.propTypes = {
   request: PropTypes.object.isRequired,
   userAvatar: PropTypes.string.isRequired,
   defaultQueryParams: PropTypes.object,
+  permissions: PropTypes.object.isRequired,
 };
 
 InvenioRequestsApp.defaultProps = {

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/Request.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/Request.js
@@ -19,7 +19,7 @@ export class Request extends Component {
   }
 
   render() {
-    const { request, updateRequestAfterAction, userAvatar } = this.props;
+    const { request, updateRequestAfterAction, userAvatar, permissions } = this.props;
 
     return (
       <Overridable id="InvenioRequest.Request.layout">
@@ -28,7 +28,7 @@ export class Request extends Component {
             request={request}
             actionSuccessCallback={updateRequestAfterAction}
           />
-          <RequestDetails request={request} userAvatar={userAvatar} />
+          <RequestDetails request={request} userAvatar={userAvatar} permissions={permissions}/>
         </Loader>
       </Overridable>
     );
@@ -40,6 +40,7 @@ Request.propTypes = {
   initRequest: PropTypes.func.isRequired,
   updateRequestAfterAction: PropTypes.func.isRequired,
   userAvatar: PropTypes.string,
+  permissions: PropTypes.object.isRequired,
 };
 
 Request.defaultProps = {

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestDetails.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestDetails.js
@@ -13,13 +13,13 @@ import { Timeline } from "../timeline";
 
 class RequestDetails extends Component {
   render() {
-    const { request, userAvatar } = this.props;
+    const { request, userAvatar, permissions } = this.props;
     return (
       <Overridable id="InvenioRequests.RequestDetails.layout" {...this.props}>
         <>
           <Grid stackable reversed="mobile">
             <Grid.Column mobile={16} tablet={12} computer={13}>
-              <Timeline userAvatar={userAvatar} />
+              <Timeline userAvatar={userAvatar} request={request} permissions={permissions}/>
             </Grid.Column>
             <Grid.Column mobile={16} tablet={4} computer={3}>
               <RequestMetadata request={request} />
@@ -34,6 +34,7 @@ class RequestDetails extends Component {
 RequestDetails.propTypes = {
   request: PropTypes.object.isRequired,
   userAvatar: PropTypes.string,
+  permissions: PropTypes.object.isRequired,
 };
 
 RequestDetails.defaultProps = {

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/requestsAppInit.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/requestsAppInit.js
@@ -12,12 +12,20 @@ import {
 import { i18next } from "@translations/invenio_requests/i18next";
 import React from "react";
 import ReactDOM from "react-dom";
+import { overrideStore } from "react-overridable";
+import { InvenioRequestsApp } from "./InvenioRequestsApp";
 import {
   RequestAcceptButton,
   RequestCancelButton,
   RequestDeclineButton,
 } from "./components/Buttons";
-import { InvenioRequestsApp } from "./InvenioRequestsApp";
+import {
+  LabelTypeCommunityInclusion,
+  LabelTypeCommunityInvitation,
+  LabelTypeCommunitySubmission,
+  LabelTypeGuestAccess,
+  LabelTypeUserAccess,
+} from "./contrib";
 import {
   AcceptStatus,
   CancelStatus,
@@ -34,14 +42,6 @@ import {
   TimelineExpireEvent,
   TimelineUnknownEvent,
 } from "./timelineEvents";
-import {
-  LabelTypeCommunityInclusion,
-  LabelTypeCommunityInvitation,
-  LabelTypeCommunitySubmission,
-  LabelTypeGuestAccess,
-  LabelTypeUserAccess,
-} from "./contrib";
-import { overrideStore } from "react-overridable";
 
 const requestDetailsDiv = document.getElementById("request-detail");
 const request = JSON.parse(requestDetailsDiv.dataset.record);
@@ -49,7 +49,7 @@ const defaultQueryParams = JSON.parse(requestDetailsDiv.dataset.defaultQueryConf
 const userAvatar = JSON.parse(requestDetailsDiv.dataset.userAvatar);
 const permissions = JSON.parse(requestDetailsDiv.dataset.permissions);
 
-const overriddenComponents = {
+const defaultComponents = {
   "TimelineEvent.layout.unknown": TimelineUnknownEvent,
   "TimelineEvent.layout.declined": TimelineDeclineEvent,
   "TimelineEvent.layout.accepted": TimelineAcceptEvent,
@@ -78,15 +78,13 @@ const overriddenComponents = {
   "RequestActionModal.title.decline": () => i18next.t("Decline request"),
 };
 
-for (const [key, value] of Object.entries(overriddenComponents)) {
-  overrideStore.add(key, value);
-}
+const overriddenComponents = overrideStore.getAll();
 
 ReactDOM.render(
   <InvenioRequestsApp
     request={request}
     defaultQueryParams={defaultQueryParams}
-    overriddenCmps={overrideStore.getAll()}
+    overriddenCmps={{ ...defaultComponents, ...overriddenComponents }}
     userAvatar={userAvatar}
     permissions={permissions}
   />,

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/requestsAppInit.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/requestsAppInit.js
@@ -41,11 +41,13 @@ import {
   LabelTypeGuestAccess,
   LabelTypeUserAccess,
 } from "./contrib";
+import { overrideStore } from "react-overridable";
 
 const requestDetailsDiv = document.getElementById("request-detail");
 const request = JSON.parse(requestDetailsDiv.dataset.record);
 const defaultQueryParams = JSON.parse(requestDetailsDiv.dataset.defaultQueryConfig);
 const userAvatar = JSON.parse(requestDetailsDiv.dataset.userAvatar);
+const permissions = JSON.parse(requestDetailsDiv.dataset.permissions);
 
 const overriddenComponents = {
   "TimelineEvent.layout.unknown": TimelineUnknownEvent,
@@ -76,12 +78,17 @@ const overriddenComponents = {
   "RequestActionModal.title.decline": () => i18next.t("Decline request"),
 };
 
+for (const [key, value] of Object.entries(overriddenComponents)) {
+  overrideStore.add(key, value);
+}
+
 ReactDOM.render(
   <InvenioRequestsApp
     request={request}
     defaultQueryParams={defaultQueryParams}
-    overriddenCmps={overriddenComponents}
+    overriddenCmps={overrideStore.getAll()}
     userAvatar={userAvatar}
+    permissions={permissions}
   />,
   requestDetailsDiv
 );

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/TimelineFeed.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/TimelineFeed.js
@@ -41,7 +41,7 @@ class TimelineFeed extends Component {
   };
 
   render() {
-    const { timeline, loading, error, setPage, size, page, userAvatar } = this.props;
+    const { timeline, loading, error, setPage, size, page, userAvatar, request, permissions } = this.props;
     const { modalOpen, modalAction } = this.state;
 
     return (
@@ -49,6 +49,7 @@ class TimelineFeed extends Component {
         <Error error={error}>
           <Overridable id="TimelineFeed.layout" {...this.props}>
             <Container id="requests-timeline" className="ml-0-mobile mr-0-mobile">
+              <Overridable id="TimelineFeed.header" request={request} permissions={permissions}/>
               <RequestsFeed>
                 {timeline.hits?.hits.map((event) => (
                   <TimelineCommentEventControlled
@@ -92,6 +93,8 @@ TimelineFeed.propTypes = {
   page: PropTypes.number,
   size: PropTypes.number,
   userAvatar: PropTypes.string,
+  request: PropTypes.object.isRequired,
+  permissions: PropTypes.object.isRequired,
 };
 
 TimelineFeed.defaultProps = {

--- a/invenio_requests/services/requests/components.py
+++ b/invenio_requests/services/requests/components.py
@@ -41,6 +41,8 @@ class RequestDataComponent(DataComponent):
         if record.status == "created":
             keys = ("title", "description", "payload", "receiver", "topic")
         else:
+            # TODO: add possibility to update payload (https://github.com/inveniosoftware/invenio-rdm-records/issues/1402)
+            # keys = ("title", "description", "payload")
             keys = ("title", "description")
 
         for k in keys:

--- a/invenio_requests/templates/semantic-ui/invenio_requests/details/index.html
+++ b/invenio_requests/templates/semantic-ui/invenio_requests/details/index.html
@@ -47,6 +47,7 @@
          data-record='{{ invenio_request | tojson }}'
          data-default-query-config='{{ dict(size=config["REQUESTS_TIMELINE_PAGE_SIZE"]) | tojson }}'
          data-user-avatar='{{ user_avatar | tojson }}'
+         data-permissions='{{ permissions | tojson }}'
     >{# react app root #}
       <div class="ui grid">
         <div class="stretched row">


### PR DESCRIPTION
* add an overridable for the timeline header
* inject permissions prop
* closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1395

NOTE: the permissions for request.payload updation should be handled in separate PR (this TODO https://github.com/inveniosoftware/invenio-requests/pull/343/files#diff-4b568e443f92c06d4ea44587cf21b1134cfaff1f5bf4ceb88076ae894c452f0fR44)
The task is already created: https://github.com/inveniosoftware/invenio-rdm-records/issues/1402
