### PR TITLE
request metadata: add record link

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js
@@ -131,7 +131,16 @@ class RequestMetadata extends Component {
               {toRelativeTime(request.expires_at, i18next.language)}
             </>
           )}
-          <Divider hidden />
+
+          {request.status === "accepted" && request.topic?.record && (
+            <>
+              <Divider />
+              <Header as="h3" size="tiny">
+                {i18next.t("Record")}
+              </Header>
+              <a href={`/records/${request.topic.record}`}>{request.title}</a>
+            </>
+          )}
         </>
       </Overridable>
     );


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/590

Adds the record link to the bottom right if request is accepted.

<img width="1143" alt="Screenshot 2023-11-28 at 5 34 36 PM" src="https://github.com/inveniosoftware/invenio-requests/assets/21052053/570d1bb1-68c5-4802-8466-cde83503ed80">
