### PR TITLE
mappings: change "dynamic" values to string

### DIFF
--- a/invenio_requests/records/mappings/os-v1/requestevents/requestevent-v1.0.0.json
+++ b/invenio_requests/records/mappings/os-v1/requestevents/requestevent-v1.0.0.json
@@ -30,7 +30,7 @@
 
       "created_by": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "id": {
         "type": "keyword"

--- a/invenio_requests/records/mappings/os-v1/requests/request-v1.0.0.json
+++ b/invenio_requests/records/mappings/os-v1/requests/request-v1.0.0.json
@@ -81,15 +81,15 @@
       },
       "created_by": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "topic": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "receiver": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "grants": {
         "type": "keyword"

--- a/invenio_requests/records/mappings/os-v2/requestevents/requestevent-v1.0.0.json
+++ b/invenio_requests/records/mappings/os-v2/requestevents/requestevent-v1.0.0.json
@@ -30,7 +30,7 @@
 
       "created_by": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "id": {
         "type": "keyword"

--- a/invenio_requests/records/mappings/os-v2/requests/request-v1.0.0.json
+++ b/invenio_requests/records/mappings/os-v2/requests/request-v1.0.0.json
@@ -81,15 +81,15 @@
       },
       "created_by": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "topic": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "receiver": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "grants": {
         "type": "keyword"

--- a/invenio_requests/records/mappings/v7/requestevents/requestevent-v1.0.0.json
+++ b/invenio_requests/records/mappings/v7/requestevents/requestevent-v1.0.0.json
@@ -30,7 +30,7 @@
 
       "created_by": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "id": {
         "type": "keyword"

--- a/invenio_requests/records/mappings/v7/requests/request-v1.0.0.json
+++ b/invenio_requests/records/mappings/v7/requests/request-v1.0.0.json
@@ -81,15 +81,15 @@
       },
       "created_by": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "topic": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "receiver": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "grants": {
         "type": "keyword"


### PR DESCRIPTION
- The mapping is stored as a string/enum in ES/OS. Using the same type
  makes sure the mapping comparison is correct when performing a
  mapping update.