### PR TITLE
Requests Comment: fix jumping cursor 

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
@@ -30,8 +30,8 @@ const TimelineCommentEditor = ({
         />
         <Container fluid className="ml-0-mobile mr-0-mobile fluid-mobile">
           <RichEditor
-            value={commentContent}
-            onChange={(event, editor) => {
+            inputValue={commentContent}
+            onEditorChange={(event, editor) => {
               setCommentContent(editor.getContent());
             }}
             minHeight={150}

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
@@ -113,8 +113,9 @@ class TimelineCommentEvent extends Component {
 
                   {isEditing ? (
                     <RichEditor
-                      value={event?.payload?.content}
-                      onChange={(event, editor) => {
+                      initialValue={event?.payload?.content}
+                      inputValue={commentContent}
+                      onEditorChange={(event, editor) => {
                         this.setState({ commentContent: editor.getContent() });
                       }}
                       minHeight={150}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

* These changes depends on: https://github.com/inveniosoftware/react-invenio-forms/pull/244
* Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2730
* Align property naming as RichEditior wrongly named value instead of initialValue
* Change `onChange` to `onEditorChange` as recommended in the `tinymce` docs.
* Change the prop `value` to `inputValue`, as `value` seems to conflict with other elements, causing the input text in edit mode to behave oddly.

![cursor-test-1](https://github.com/inveniosoftware/invenio-requests/assets/36583694/23116d28-6c79-49c3-9dc8-8ea74b24be0a)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
