### PR TITLE
i18n: Fix untranslated strings in facets

### DIFF
--- a/invenio_requests/resources/requests/fields.py
+++ b/invenio_requests/resources/requests/fields.py
@@ -8,6 +8,7 @@
 
 """Marshmallow fields for search parameter deserialization."""
 
+from invenio_i18n import lazy_gettext as _
 from marshmallow import fields
 
 
@@ -20,7 +21,7 @@ class ReferenceString(fields.Field):
 
     #: Default error messages.
     default_error_messages = {
-        "invalid": "Not a valid reference.",
+        "invalid": _("Not a valid reference."),
     }
 
     def _deserialize(self, value, attr, data, **kwargs):

--- a/invenio_requests/services/requests/facets.py
+++ b/invenio_requests/services/requests/facets.py
@@ -8,7 +8,7 @@
 
 """Facet definitions."""
 
-from invenio_i18n import gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.records.facets import TermsFacet
 
 type = TermsFacet(


### PR DESCRIPTION
### Description

Fix: some strings that could appear inside UI were not marked with gettext/lazy_gettext.

This PR adds lazy_gettext into places where the string is read when invenio is started (static initialization) and gettext elsewhere

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
