### PR TITLE
Flask v3 upgrade

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 ..
     Copyright (C) 2021-2024 CERN.
+    Copyright (C) 2024 Graz University of Technology.
 
     Invenio-Requests is free software; you can redistribute it and/or
     modify it under the terms of the MIT License; see LICENSE file for more
@@ -7,6 +8,12 @@
 
 Changes
 =======
+
+Version 6.0.0.dev1 (released 2024-12-12)
+
+- fix: sqlalchemy.exc.ArgumentError
+- comp: make compatible to flask-sqlalchemy>=3.1
+- setup: bump major dependencies
 
 Version v5.5.0 (released 2024-12-09)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version v6.0.0 (released 2025-02-13)
+
+- Promote to stable release.
+
 Version v6.0.0.dev2 (released 2025-01-23)
 
 Version v6.0.0.dev1 (released 2024-12-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,9 @@
 Changes
 =======
 
-Version 6.0.0.dev1 (released 2024-12-12)
+Version v6.0.0.dev2 (released 2025-01-23)
+
+Version v6.0.0.dev1 (released 2024-12-12)
 
 - fix: sqlalchemy.exc.ArgumentError
 - comp: make compatible to flask-sqlalchemy>=3.1

--- a/invenio_requests/__init__.py
+++ b/invenio_requests/__init__.py
@@ -20,7 +20,7 @@ from .proxies import (
     current_requests_service,
 )
 
-__version__ = "5.5.0"
+__version__ = "6.0.0.dev1"
 
 __all__ = (
     "__version__",

--- a/invenio_requests/__init__.py
+++ b/invenio_requests/__init__.py
@@ -20,7 +20,7 @@ from .proxies import (
     current_requests_service,
 )
 
-__version__ = "6.0.0.dev1"
+__version__ = "6.0.0.dev2"
 
 __all__ = (
     "__version__",

--- a/invenio_requests/__init__.py
+++ b/invenio_requests/__init__.py
@@ -20,7 +20,7 @@ from .proxies import (
     current_requests_service,
 )
 
-__version__ = "6.0.0.dev2"
+__version__ = "6.0.0"
 
 __all__ = (
     "__version__",

--- a/invenio_requests/records/models.py
+++ b/invenio_requests/records/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-Requests is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -15,6 +16,7 @@ from sqlalchemy import func
 from sqlalchemy.dialects import mysql
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.sql import text
 from sqlalchemy.types import String
 from sqlalchemy_utils import UUIDType
 
@@ -109,9 +111,9 @@ class SequenceMixin:
         """
         if db.engine.dialect.name == "postgresql":  # pragma: no cover
             db.session.execute(
-                "SELECT setval(pg_get_serial_sequence("
-                "'{0}', 'value'), :newval)".format(cls.__tablename__),
-                dict(newval=val),
+                text(
+                    "SELECT setval(pg_get_serial_sequence(:table, 'value'), :newval)"
+                ).bindparams(newval=val, table=cls.__tablename__),
             )
 
     @classmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,23 +26,23 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-records-resources>=6.0.0,<7.0.0
-    invenio-theme>=3.0.0,<4.0.0
-    invenio-users-resources>=6.0.0,<7.0.0
+    invenio-records-resources>=7.0.0,<8.0.0
+    invenio-theme>=4.0.0,<5.0.0
+    invenio-users-resources>=7.0.0.dev1,<8.0.0
 
 [options.extras_require]
 tests =
     pytest-black-ng>=0.4.0
-    invenio-app>=1.4.0,<2.0.0
-    invenio-db[postgresql,mysql]>=1.0.13,<2.0.0
-    pytest-invenio>=2.1.0,<3.0.0
+    invenio-app>=2.0.0,<3.0.0
+    invenio-db[postgresql,mysql]>=2.0.0,<3.0.0
+    pytest-invenio>=3.0.0,<4.0.0
     sphinx>=4.5.0
 elasticsearch7 =
-    invenio-search[elasticsearch7]>=2.1.0,<3.0.0
+    invenio-search[elasticsearch7]>=3.0.0,<4.0.0
 opensearch1 =
-    invenio-search[opensearch1]>=2.1.0,<3.0.0
+    invenio-search[opensearch1]>=3.0.0,<4.0.0
 opensearch2 =
-    invenio-search[opensearch2]>=2.1.0,<3.0.0
+    invenio-search[opensearch2]>=3.0.0,<4.0.0
 
 [options.entry_points]
 invenio_base.apps =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ zip_safe = False
 install_requires =
     invenio-records-resources>=7.0.0,<8.0.0
     invenio-theme>=4.0.0,<5.0.0
-    invenio-users-resources>=7.0.0.dev1,<8.0.0
+    invenio-users-resources>=7.0.0.dev2,<8.0.0
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ zip_safe = False
 install_requires =
     invenio-records-resources>=7.0.0,<8.0.0
     invenio-theme>=4.0.0,<5.0.0
-    invenio-users-resources>=7.0.0.dev2,<8.0.0
+    invenio-users-resources>=7.0.0,<8.0.0
 
 [options.extras_require]
 tests =

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2021 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -23,7 +24,7 @@ def test_alembic(base_app, database):
     base_app.config["ALEMBIC_CONTEXT"] = alembic_test_context()
 
     # Check that this package's SQLAlchemy models have been properly registered
-    tables = [x.name for x in db.get_tables_for_bind()]
+    tables = [x for x in db.metadata.tables]
     assert "request_metadata" in tables
     assert "request_events" in tables
 


### PR DESCRIPTION
- Depends on https://github.com/inveniosoftware/invenio-users-resources/pull/156 and `7.0.0` release
- **setup: bump major dependencies** 
- **comp: make compatible to flask-sqlalchemy>=3.1**
- **fix: sqlalchemy.exc.ArgumentError**
  * Textual SQL expression 'SELECT setval(pg_get_seri...' should be
    explicitly declared as text('SELECT setval(pg_get_seri...')
- **release: v6.0.0.dev1**
- **installation: bump invenio-users-resources**