### PR TITLE
message-index: remove depreciated languages

### DIFF
--- a/invenio_requests/assets/semantic-ui/translations/invenio_requests/messages/index.js
+++ b/invenio_requests/assets/semantic-ui/translations/invenio_requests/messages/index.js
@@ -1,4 +1,3 @@
-import TRANSLATE_AF from "./af/translations.json";
 import TRANSLATE_AR from "./ar/translations.json";
 import TRANSLATE_BG from "./bg/translations.json";
 import TRANSLATE_CA from "./ca/translations.json";
@@ -9,10 +8,8 @@ import TRANSLATE_EL from "./el/translations.json";
 import TRANSLATE_EN from "./en/translations.json";
 import TRANSLATE_ES from "./es/translations.json";
 import TRANSLATE_ET from "./et/translations.json";
-import TRANSLATE_ET_EE from "./et_EE/translations.json";
 import TRANSLATE_FA from "./fa/translations.json";
 import TRANSLATE_FR from "./fr/translations.json";
-import TRANSLATE_GL from "./gl/translations.json";
 import TRANSLATE_HR from "./hr/translations.json";
 import TRANSLATE_HU from "./hu/translations.json";
 import TRANSLATE_IT from "./it/translations.json";
@@ -24,7 +21,6 @@ import TRANSLATE_PL from "./pl/translations.json";
 import TRANSLATE_PT from "./pt/translations.json";
 import TRANSLATE_RO from "./ro/translations.json";
 import TRANSLATE_RU from "./ru/translations.json";
-import TRANSLATE_RW from "./rw/translations.json";
 import TRANSLATE_SK from "./sk/translations.json";
 import TRANSLATE_SV from "./sv/translations.json";
 import TRANSLATE_TR from "./tr/translations.json";
@@ -33,7 +29,6 @@ import TRANSLATE_ZH_CN from "./zh_CN/translations.json";
 import TRANSLATE_ZH_TW from "./zh_TW/translations.json";
 
 export const translations = {
-  af: { translation: TRANSLATE_AF },
   ar: { translation: TRANSLATE_AR },
   bg: { translation: TRANSLATE_BG },
   ca: { translation: TRANSLATE_CA },
@@ -44,10 +39,8 @@ export const translations = {
   en: { translation: TRANSLATE_EN },
   es: { translation: TRANSLATE_ES },
   et: { translation: TRANSLATE_ET },
-  et_EE: { translation: TRANSLATE_ET_EE },
   fa: { translation: TRANSLATE_FA },
   fr: { translation: TRANSLATE_FR },
-  gl: { translation: TRANSLATE_GL },
   hr: { translation: TRANSLATE_HR },
   hu: { translation: TRANSLATE_HU },
   it: { translation: TRANSLATE_IT },
@@ -59,7 +52,6 @@ export const translations = {
   pt: { translation: TRANSLATE_PT },
   ro: { translation: TRANSLATE_RO },
   ru: { translation: TRANSLATE_RU },
-  rw: { translation: TRANSLATE_RW },
   sk: { translation: TRANSLATE_SK },
   sv: { translation: TRANSLATE_SV },
   tr: { translation: TRANSLATE_TR },


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Remove depreciated languages from index



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
