### PR TITLE
Extra context for permission checks

### DIFF
--- a/invenio_requests/services/events/service.py
+++ b/invenio_requests/services/events/service.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2021-2022 Northwestern University.
 # Copyright (C) 2021-2022 TU Wien.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Requests is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -77,6 +78,7 @@ class RequestEventsService(RecordService):
         expand=False,
         notify=True,
         parent_id=None,
+        **kwargs,
     ):
         """Create a request event (top-level or reply).
 
@@ -87,13 +89,29 @@ class RequestEventsService(RecordService):
         :param parent_id: Optional parent event ID for replies.
         """
         request = self._get_request(request_id)
-        self.require_permission(identity, "read", request=request)
+        self.require_permission(
+            identity,
+            "read",
+            request=request,
+            data=data,
+            event_type=event_type,
+            notify=notify,
+            **kwargs,
+        )
         try:
             # If the event is a log, we don't check for permissions to not block logs creation
             if event_type.type_id != LogEventType.type_id:
                 # Check permission based on whether this is a reply or top-level comment
                 permission = "reply_comment" if parent_id else "create_comment"
-                self.require_permission(identity, permission, request=request)
+                self.require_permission(
+                    identity,
+                    permission,
+                    request=request,
+                    data=data,
+                    event_type=event_type,
+                    notify=notify,
+                    **kwargs,
+                )
         except PermissionDeniedError:
             if current_app.config.get(
                 "REQUESTS_LOCKING_ENABLED", False
@@ -182,12 +200,12 @@ class RequestEventsService(RecordService):
             request=request,
         )
 
-    def read(self, identity, id_, expand=False):
+    def read(self, identity, id_, expand=False, **kwargs):
         """Retrieve a record."""
         event = self._get_event(id_)
         request = self._get_request(event.request_id)
 
-        self.require_permission(identity, "read", request=request)
+        self.require_permission(identity, "read", request=request, **kwargs)
 
         return self.result_item(
             self,
@@ -203,13 +221,20 @@ class RequestEventsService(RecordService):
         )
 
     @unit_of_work()
-    def update(self, identity, id_, data, revision_id=None, uow=None, expand=False):
+    def update(
+        self, identity, id_, data, revision_id=None, uow=None, expand=False, **kwargs
+    ):
         """Update a comment (only comments can be updated)."""
         event = self._get_event(id_)
         request = self._get_request(event.request.id)
         try:
             self.require_permission(
-                identity, "update_comment", request=request, event=event
+                identity,
+                "update_comment",
+                request=request,
+                event=event,
+                data=data,
+                **kwargs,
             )
         except PermissionDeniedError:
             if current_app.config.get(
@@ -275,7 +300,7 @@ class RequestEventsService(RecordService):
         )
 
     @unit_of_work()
-    def delete(self, identity, id_, revision_id=None, uow=None):
+    def delete(self, identity, id_, revision_id=None, uow=None, **kwargs):
         """Delete a comment (only comments can be deleted)."""
         event = self._get_event(id_)
         request_id = event.request_id
@@ -283,7 +308,7 @@ class RequestEventsService(RecordService):
 
         # Permissions
         self.require_permission(
-            identity, "delete_comment", request=request, event=event
+            identity, "delete_comment", request=request, event=event, **kwargs
         )
         self.check_revision_id(event, revision_id)
 
@@ -356,7 +381,9 @@ class RequestEventsService(RecordService):
 
         # Permissions - guarded by the request's can_read.
         request = self._get_request(request_id)
-        self.require_permission(identity, "read", request=request)
+        self.require_permission(
+            identity, "read", request=request, params=params, **kwargs
+        )
 
         # Build query for top-level events (parents) with optional children preview
         # Uses join relationships to include children via inner_hits when they exist

--- a/invenio_requests/services/requests/service.py
+++ b/invenio_requests/services/requests/service.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021-2025 CERN.
 # Copyright (C) 2021 Northwestern University.
 # Copyright (C) 2021 - 2022 TU Wien.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Requests is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -76,9 +77,20 @@ class RequestsService(RecordService):
         expires_at=None,
         uow=None,
         expand=False,
+        **kwargs,
     ):
         """Create a record."""
-        self.require_permission(identity, "create")
+        self.require_permission(
+            identity,
+            "create",
+            data=data,
+            request_type=request_type,
+            receiver=receiver,
+            creator=creator,
+            record=topic,
+            expires_at=expires_at,
+            **kwargs,
+        )
 
         # we're not using "self.schema" b/c the schema may differ per
         # request type!
@@ -136,11 +148,11 @@ class RequestsService(RecordService):
             expand=expand,
         )
 
-    def read(self, identity, id_, expand=False):
+    def read(self, identity, id_, expand=False, **kwargs):
         """Retrieve a request."""
         # resolve and require permission
         request = self.record_cls.get_record(id_)
-        self.require_permission(identity, "read", request=request)
+        self.require_permission(identity, "read", request=request, **kwargs)
 
         # run components
         for component in self.components:
@@ -158,13 +170,17 @@ class RequestsService(RecordService):
         )
 
     @unit_of_work()
-    def update(self, identity, id_, data, revision_id=None, uow=None, expand=False):
+    def update(
+        self, identity, id_, data, revision_id=None, uow=None, expand=False, **kwargs
+    ):
         """Update a request."""
         request = self.record_cls.get_record(id_)
 
         self.check_revision_id(request, revision_id)
 
-        self.require_permission(identity, "update", record=request, request=request)
+        self.require_permission(
+            identity, "update", record=request, request=request, data=data, **kwargs
+        )
 
         # we're not using "self.schema" b/c the schema may differ per
         # request type!
@@ -197,7 +213,7 @@ class RequestsService(RecordService):
         )
 
     @unit_of_work()
-    def delete(self, identity, id_, uow=None):
+    def delete(self, identity, id_, uow=None, **kwargs):
         """Delete a request from database and search indexes."""
         request = self.record_cls.get_record(id_)
 
@@ -205,7 +221,7 @@ class RequestsService(RecordService):
         # self.check_revision_id(request, revision_id)
 
         # check permissions
-        self.require_permission(identity, "action_delete", request=request)
+        self.require_permission(identity, "action_delete", request=request, **kwargs)
 
         # run components
         self.run_components("delete", identity, record=request, uow=uow)
@@ -241,7 +257,14 @@ class RequestsService(RecordService):
 
         # Check permissions - example of permission: can_cancel_submitted
         permission_name = f"action_{action}"
-        self.require_permission(identity, permission_name, request=request)
+        self.require_permission(
+            identity,
+            permission_name,
+            request=request,
+            action_obj=action_obj,
+            data=data,
+            **kwargs,
+        )
 
         # Check if the action *can* be executed (i.e. a given state transition
         # is allowed).
@@ -282,7 +305,9 @@ class RequestsService(RecordService):
         The user is able to search the requests that were created by them
         they are the receiver or they got access via the requests topic e.g record sharing.
         """
-        self.require_permission(identity, "search_user_requests")
+        self.require_permission(
+            identity, "search_user_requests", params=params, **kwargs
+        )
 
         # Prepare and execute the search
         params = params or {}


### PR DESCRIPTION
### Description

At CESNET we extend requests' services to have them as first class citizens (we have REST API to create requests in a generic way). In order to do so, we need to extend permission checks so that they not only include requests but also create/update data and additional parameters from context.

This pull request:

- add kwargs to service methods
- passes the kwargs data and additional context to permission checks

This change is 100% backwards compatible and in RDM **does not** cause any differences in permission handling 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
