### PR TITLE
services: include Opensearch meta in the results

### DIFF
--- a/invenio_requests/services/events/config.py
+++ b/invenio_requests/services/events/config.py
@@ -51,6 +51,7 @@ class RequestEventList(RecordList):
                 context=dict(
                     identity=self._identity,
                     record=record,
+                    meta=hit.meta,
                 ),
             )
 

--- a/invenio_requests/services/requests/results.py
+++ b/invenio_requests/services/requests/results.py
@@ -150,6 +150,7 @@ class RequestList(RecordList):
                 context={
                     "identity": self._identity,
                     "record": request,
+                    "meta": hit.meta,
                 },
             )
 


### PR DESCRIPTION
Sometimes, keys relevant to the serialization process are not included inside ``_source``, i.e. "highlight." By adding ``hit.meta`` as part of the serializer context, we make them available without the risk of name collision.

