### PR TITLE
Adding component calls to RequestEventsService methods

### DIFF
--- a/invenio_requests/services/events/config.py
+++ b/invenio_requests/services/events/config.py
@@ -92,3 +92,8 @@ class RequestEventsServiceConfig(RecordServiceConfig, ConfiguratorMixin):
         "self": RequestEventLink("{+api}/requests/{request_id}/comments/{id}"),
     }
     links_search = pagination_links("{+api}/requests/{request_id}/timeline{?args*}")
+
+    components = FromConfig(
+        "REQUESTS_EVENTS_SERVICE_COMPONENTS",
+        default=[],
+    )

--- a/invenio_requests/services/events/service.py
+++ b/invenio_requests/services/events/service.py
@@ -73,6 +73,17 @@ class RequestEventsService(RecordService):
         )
         event.update(data)
         event.created_by = self._get_creator(identity, request=request)
+
+        # Run components
+        self.run_components(
+            "create",
+            identity,
+            data=data,
+            event=event,
+            errors=errors,
+            uow=uow,
+        )
+
         # Persist record (DB and index)
         uow.register(RecordCommitOp(event, indexer=self.indexer))
 
@@ -130,6 +141,18 @@ class RequestEventsService(RecordService):
         )
         event["payload"]["content"] = data["payload"]["content"]
         event["payload"]["format"] = data["payload"]["format"]
+
+        # Run components
+        self.run_components(
+            "update_comment",
+            identity,
+            data=data,
+            event=event,
+            request=request,
+            uow=uow,
+        )
+
+        # Persist record (DB and index)
         uow.register(RecordCommitOp(event, indexer=self.indexer))
 
         return self.result_item(
@@ -173,6 +196,17 @@ class RequestEventsService(RecordService):
             context=dict(identity=identity, record=event, event_type=event.type),
         )
         event["payload"] = data["payload"]
+
+        # Run components
+        self.run_components(
+            "delete_comment",
+            identity,
+            data=data,
+            event=event,
+            request=request,
+            uow=uow,
+        )
+
         uow.register(RecordCommitOp(event, indexer=self.indexer))
 
         return True


### PR DESCRIPTION
### Description

Adds service component calls to the `create`, `update`, and `delete` methods of the RequestEventsService class, since it lacked them. Also adds a config variable that provides a configurable list of service components via the service's config class.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [X] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
