### PR TITLE
chores: replaced importlib_xyz with importlib

### DIFF
--- a/invenio_requests/ext.py
+++ b/invenio_requests/ext.py
@@ -12,7 +12,7 @@
 
 import inspect
 
-from importlib_metadata import entry_points
+from invenio_base.utils import entry_points
 
 from . import config
 from .registry import TypeRegistry
@@ -116,7 +116,7 @@ class InvenioRequests:
 
 def register_entry_point(registry, ep_name, app=None):
     """Register types from an entry point."""
-    for ep in set(entry_points(group=ep_name)):
+    for ep in entry_points(group=ep_name):
         loaded_ep = ep.load()
         type_cls = loaded_ep
         # Allow to load class from functions (note: classes are callable too)


### PR DESCRIPTION
### Description

Replaced `importlib_metadata` and `importlib_resources` with `importlib`.

* Using invenio_base.utils.entry_points for entry_points

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
