### PR TITLE
requests: fix request UI when no receiver is allowed

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js
@@ -177,20 +177,22 @@ class RequestMetadata extends Component {
               <Divider />
             </>
           )}
-
-          <Header as="h3" size="tiny">
-            {i18next.t("Receiver")}
-          </Header>
-          {this.isResourceDeleted(expandedReceiver) ? (
-            <DeletedResource details={expandedReceiver} />
-          ) : (
-            <EntityDetails
-              userData={request.receiver}
-              details={request.expanded?.receiver}
-            />
+          {expandedReceiver !== undefined && (
+            <>
+              <Header as="h3" size="tiny">
+                {i18next.t("Receiver")}
+              </Header>
+              {this.isResourceDeleted(expandedReceiver) ? (
+                <DeletedResource details={expandedReceiver} />
+              ) : (
+                <EntityDetails
+                  userData={request.receiver}
+                  details={request.expanded?.receiver}
+                />
+              )}
+              <Divider />
+            </>
           )}
-          <Divider />
-
           <Header as="h3" size="tiny">
             {i18next.t("Request type")}
           </Header>

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/search/ComputerTabletRequestItem.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/search/ComputerTabletRequestItem.js
@@ -88,7 +88,7 @@ export const ComputerTabletRequestItem = ({
             {creatorName}
           </small>
           <small className="right floated">
-            {result.receiver.community && result.expanded?.receiver.metadata.title && (
+            {result.receiver?.community && result.expanded?.receiver?.metadata.title && (
               <>
                 <Icon
                   className="default-margin"

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/search/MobileRequestItem.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/search/MobileRequestItem.js
@@ -76,7 +76,7 @@ export const MobileRequestItem = ({
             {creatorName}
           </small>
           <small className="block rel-mt-1">
-            {result.receiver.community && result.expanded?.receiver.metadata.title && (
+            {result.receiver?.community && result.expanded?.receiver?.metadata.title && (
               <>
                 <Icon
                   className="default-margin"


### PR DESCRIPTION
We allow the receiver to be none on the backend, but since it was not used until now, the frontend was probably to tested for it. We are using this for the `record-deletion` request type and came across the issue.