### PR TITLE
feat(events): deep links

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/api/InvenioRequestApi.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/api/InvenioRequestApi.js
@@ -6,13 +6,18 @@
 
 import _isEmpty from "lodash/isEmpty";
 import { http } from "react-invenio-forms";
+import { i18next } from "@translations/invenio_requests/i18next";
 
 export class RequestLinksExtractor {
   #urls;
 
   constructor(request) {
     if (!request?.links) {
-      throw TypeError("Request resource links are undefined");
+      throw TypeError(
+        i18next.t("{{link_name}} links are undefined. Please refresh the page.", {
+          link_name: "Request resource",
+        })
+      );
     }
     this.#urls = request.links;
   }
@@ -23,21 +28,44 @@ export class RequestLinksExtractor {
 
   get timeline() {
     if (!this.#urls.timeline) {
-      throw TypeError("Timeline link missing from resource.");
+      throw TypeError(
+        i18next.t("{{link_name}} link missing from resource.", {
+          link_name: "Timeline",
+        })
+      );
     }
     return this.#urls.timeline;
   }
 
+  get timelineFocused() {
+    if (!this.#urls.timeline_focused) {
+      throw TypeError(
+        i18next.t("{{link_name}} link missing from resource.", {
+          link_name: "Focused timeline",
+        })
+      );
+    }
+    return this.#urls.timeline_focused;
+  }
+
   get comments() {
     if (!this.#urls.comments) {
-      throw TypeError("Comments link missing from resource.");
+      throw TypeError(
+        i18next.t("{{link_name}} link missing from resource.", {
+          link_name: "Comments",
+        })
+      );
     }
     return this.#urls.comments;
   }
 
   get actions() {
     if (!this.#urls.actions) {
-      throw TypeError("Actions link missing from resource.");
+      throw TypeError(
+        i18next.t("{{link_name}} link missing from resource.", {
+          link_name: "Actions",
+        })
+      );
     }
     return this.#urls.actions;
   }
@@ -58,6 +86,16 @@ export class InvenioRequestsAPI {
     return await http.get(this.#urls.timeline, {
       params: {
         expand: 1,
+        ...params,
+      },
+    });
+  };
+
+  getTimelineFocused = async (focusEventId, params) => {
+    return await http.get(this.#urls.timelineFocused, {
+      params: {
+        expand: 1,
+        focus_event_id: focusEventId,
         ...params,
       },
     });

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/api/InvenioRequestEventsApi.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/api/InvenioRequestEventsApi.js
@@ -4,6 +4,7 @@
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 import { http } from "react-invenio-forms";
+import { i18next } from "@translations/invenio_requests/i18next";
 
 export class RequestEventsLinksExtractor {
   #links;
@@ -14,9 +15,24 @@ export class RequestEventsLinksExtractor {
 
   get eventUrl() {
     if (!this.#links.self) {
-      throw TypeError("Self link missing from resource.");
+      throw TypeError(
+        i18next.t("{{link_name}} link missing from resource.", {
+          link_name: "Self",
+        })
+      );
     }
     return this.#links.self;
+  }
+
+  get eventHtmlUrl() {
+    if (!this.#links.self_html) {
+      throw TypeError(
+        i18next.t("{{link_name}} link missing from resource.", {
+          link_name: "Self HTML",
+        })
+      );
+    }
+    return this.#links.self_html;
   }
 }
 

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/components/RequestsFeed.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/components/RequestsFeed.js
@@ -6,7 +6,7 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import PropTypes from "prop-types";
-import React from "react";
+import React, { forwardRef } from "react";
 import { Image } from "react-invenio-forms";
 import { Container, Feed, Icon } from "semantic-ui-react";
 
@@ -26,18 +26,31 @@ RequestsFeed.defaultProps = {
   children: null,
 };
 
-export const RequestEventItem = ({ children }) => (
-  <div className="requests-event-item">
-    <div className="requests-event-container">{children}</div>
-  </div>
-);
+export const RequestEventItem = forwardRef(function RequestEventItem(
+  { id, children, selected },
+  ref
+) {
+  return (
+    <div
+      className={`requests-event-item${selected ? " selected" : ""}`}
+      id={id}
+      ref={ref}
+    >
+      <div className="requests-event-container">{children}</div>
+    </div>
+  );
+});
 
 RequestEventItem.propTypes = {
+  id: PropTypes.string,
   children: PropTypes.node,
+  selected: PropTypes.bool,
 };
 
 RequestEventItem.defaultProps = {
+  id: null,
   children: null,
+  selected: false,
 };
 
 export const RequestEventInnerContainer = ({ children, isEvent }) => (

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/TimelineFeed.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/TimelineFeed.js
@@ -9,7 +9,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Overridable from "react-overridable";
-import { Container, Divider } from "semantic-ui-react";
+import { Container, Divider, Message, Icon } from "semantic-ui-react";
 import Error from "../components/Error";
 import Loader from "../components/Loader";
 import { DeleteConfirmationModal } from "../components/modals/DeleteConfirmationModal";
@@ -17,6 +17,7 @@ import { Pagination } from "../components/Pagination";
 import RequestsFeed from "../components/RequestsFeed";
 import { TimelineCommentEditor } from "../timelineCommentEditor";
 import { TimelineCommentEventControlled } from "../timelineCommentEventControlled";
+import { getEventIdFromUrl } from "../timelineEvents/utils";
 
 class TimelineFeed extends Component {
   constructor(props) {
@@ -30,7 +31,9 @@ class TimelineFeed extends Component {
 
   componentDidMount() {
     const { getTimelineWithRefresh } = this.props;
-    getTimelineWithRefresh();
+
+    // Check if an event ID is included in the hash
+    getTimelineWithRefresh(getEventIdFromUrl());
   }
 
   async componentDidUpdate(prevProps) {
@@ -63,12 +66,22 @@ class TimelineFeed extends Component {
       userAvatar,
       request,
       permissions,
+      warning,
     } = this.props;
     const { modalOpen, modalAction } = this.state;
 
     return (
       <Loader isLoading={loading}>
         <Error error={error}>
+          {warning && (
+            <Message visible warning>
+              <p>
+                <Icon name="warning sign" />
+                {warning}
+              </p>
+            </Message>
+          )}
+
           <Overridable id="TimelineFeed.layout" {...this.props}>
             <Container id="requests-timeline" className="ml-0-mobile mr-0-mobile">
               <Overridable
@@ -122,6 +135,7 @@ TimelineFeed.propTypes = {
   request: PropTypes.object.isRequired,
   permissions: PropTypes.object.isRequired,
   loading: PropTypes.bool.isRequired,
+  warning: PropTypes.string,
 };
 
 TimelineFeed.defaultProps = {
@@ -131,6 +145,7 @@ TimelineFeed.defaultProps = {
   page: 1,
   size: 10,
   userAvatar: "",
+  warning: null,
 };
 
 export default Overridable.component("TimelineFeed", TimelineFeed);

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/index.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/index.js
@@ -13,7 +13,8 @@ import {
 import TimelineFeedComponent from "./TimelineFeed";
 
 const mapDispatchToProps = (dispatch) => ({
-  getTimelineWithRefresh: () => dispatch(getTimelineWithRefresh()),
+  getTimelineWithRefresh: (includeEventId) =>
+    dispatch(getTimelineWithRefresh(includeEventId)),
   timelineStopRefresh: () => dispatch(clearTimelineInterval()),
   setPage: (page) => dispatch(setPage(page)),
 });
@@ -26,6 +27,7 @@ const mapStateToProps = (state) => ({
   isSubmitting: state.timelineCommentEditor.isLoading,
   size: state.timeline.size,
   page: state.timeline.page,
+  warning: state.timeline.warning,
 });
 
 export const Timeline = connect(

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/state/reducer.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/state/reducer.js
@@ -4,7 +4,15 @@
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import { CHANGE_PAGE, HAS_ERROR, IS_LOADING, IS_REFRESHING, SUCCESS } from "./actions";
+import { i18next } from "@translations/invenio_requests/i18next";
+import {
+  CHANGE_PAGE,
+  HAS_ERROR,
+  IS_LOADING,
+  IS_REFRESHING,
+  MISSING_REQUESTED_EVENT,
+  SUCCESS,
+} from "./actions";
 
 export const initialState = {
   loading: false,
@@ -13,6 +21,7 @@ export const initialState = {
   error: null,
   size: 15,
   page: 1,
+  warning: null,
 };
 
 export const timelineReducer = (state = initialState, action) => {
@@ -40,6 +49,14 @@ export const timelineReducer = (state = initialState, action) => {
       return {
         ...state,
         page: action.payload,
+        warning: null,
+      };
+    case MISSING_REQUESTED_EVENT:
+      return {
+        ...state,
+        warning: i18next.t(
+          "The requested comment was not found. The first page of comments is shown instead."
+        ),
       };
 
     default:

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
@@ -6,7 +6,7 @@
 
 import { i18next } from "@translations/invenio_requests/i18next";
 import PropTypes from "prop-types";
-import React, { Component } from "react";
+import React, { Component, createRef } from "react";
 import { Image } from "react-invenio-forms";
 import Overridable from "react-overridable";
 import { Container, Dropdown, Feed, Icon } from "semantic-ui-react";
@@ -16,6 +16,8 @@ import { RichEditor } from "react-invenio-forms";
 import RequestsFeed from "../components/RequestsFeed";
 import { TimelineEventBody } from "../components/TimelineEventBody";
 import { toRelativeTime } from "react-invenio-forms";
+import { isEventSelected } from "./utils";
+import { RequestEventsLinksExtractor } from "../api/InvenioRequestEventsApi.js";
 
 class TimelineCommentEvent extends Component {
   constructor(props) {
@@ -25,8 +27,30 @@ class TimelineCommentEvent extends Component {
 
     this.state = {
       commentContent: event?.payload?.content,
+      isSelected: false,
     };
+    this.ref = createRef(null);
   }
+
+  componentDidMount() {
+    window.addEventListener("hashchange", this.updateSelected);
+    this.updateSelected();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("hashchange", this.updateSelected);
+  }
+
+  updateSelected = () => {
+    const { event } = this.props;
+    const isSelected = isEventSelected(event);
+    this.setState({ isSelected });
+    if (isSelected && this.ref.current) {
+      // We need to manually focus the element since it will have been loaded after the initial page load.
+      this.ref.current.scrollIntoView({ behaviour: "smooth" });
+      this.ref.current.focus();
+    }
+  };
 
   eventToType = ({ type, payload }) => {
     switch (type) {
@@ -41,6 +65,13 @@ class TimelineCommentEvent extends Component {
     }
   };
 
+  copyLink() {
+    const {
+      event: { links },
+    } = this.props;
+    navigator.clipboard.writeText(new RequestEventsLinksExtractor(links).eventHtmlUrl);
+  }
+
   render() {
     const {
       isLoading,
@@ -51,7 +82,7 @@ class TimelineCommentEvent extends Component {
       deleteComment,
       toggleEditMode,
     } = this.props;
-    const { commentContent } = this.state;
+    const { commentContent, isSelected } = this.state;
 
     const commentHasBeenEdited = event?.revision_id > 1 && event?.payload;
 
@@ -73,34 +104,42 @@ class TimelineCommentEvent extends Component {
       userAvatar = <Icon size="large" name="user circle outline" />;
       userName = createdBy.email;
     }
+
+    const eventSelfURL = new URL(
+      new RequestEventsLinksExtractor(event.links).eventHtmlUrl
+    );
+    // Remove the # character from the start of the hash
+    const eventItemId = eventSelfURL.hash.substring(1);
+
     return (
       <Overridable id={`TimelineEvent.layout.${this.eventToType(event)}`} event={event}>
-        <RequestsFeed.Item>
+        <RequestsFeed.Item id={eventItemId} ref={this.ref} selected={isSelected}>
           <RequestsFeed.Content>
             {userAvatar}
             <RequestsFeed.Event>
               <Feed.Content>
-                {(canDelete || canUpdate) && (
-                  <Dropdown
-                    icon="ellipsis horizontal"
-                    className="right-floated"
-                    direction="left"
-                    aria-label={i18next.t("Actions")}
-                  >
-                    <Dropdown.Menu>
-                      {canUpdate && (
-                        <Dropdown.Item onClick={() => toggleEditMode()}>
-                          {i18next.t("Edit")}
-                        </Dropdown.Item>
-                      )}
-                      {canDelete && (
-                        <Dropdown.Item onClick={() => deleteComment()}>
-                          {i18next.t("Delete")}
-                        </Dropdown.Item>
-                      )}
-                    </Dropdown.Menu>
-                  </Dropdown>
-                )}
+                <Dropdown
+                  icon="ellipsis horizontal"
+                  className="right-floated"
+                  direction="left"
+                  aria-label={i18next.t("Actions")}
+                >
+                  <Dropdown.Menu>
+                    <Dropdown.Item onClick={() => this.copyLink()}>
+                      {i18next.t("Copy link")}
+                    </Dropdown.Item>
+                    {canUpdate && (
+                      <Dropdown.Item onClick={() => toggleEditMode()}>
+                        {i18next.t("Edit")}
+                      </Dropdown.Item>
+                    )}
+                    {canDelete && (
+                      <Dropdown.Item onClick={() => deleteComment()}>
+                        {i18next.t("Delete")}
+                      </Dropdown.Item>
+                    )}
+                  </Dropdown.Menu>
+                </Dropdown>
                 <Feed.Summary>
                   <b>{userName}</b>
                   <Feed.Date>

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/utils.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/utils.js
@@ -1,0 +1,24 @@
+// This file is part of InvenioRequests
+// Copyright (C) 2025 CERN.
+//
+// Invenio Requests is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { RequestEventsLinksExtractor } from "../api/InvenioRequestEventsApi";
+
+export const isEventSelected = (event) => {
+  const eventUrl = new URL(new RequestEventsLinksExtractor(event.links).eventHtmlUrl);
+  const currentUrl = new URL(window.location.href);
+  return eventUrl.hash === currentUrl.hash;
+};
+
+export const getEventIdFromUrl = () => {
+  const currentUrl = new URL(window.location.href);
+  const hash = currentUrl.hash;
+  let eventId = null;
+  const commentPrefix = "#commentevent-";
+  if (hash.startsWith(commentPrefix)) {
+    eventId = hash.substring(commentPrefix.length);
+  }
+  return eventId;
+};

--- a/invenio_requests/notifications/generators.py
+++ b/invenio_requests/notifications/generators.py
@@ -57,6 +57,7 @@ class RequestParticipantsRecipient(RecipientGenerator):
 
         # fetching all request events to get involved users
         request_events = current_events_service.scan(
+            request_id=request["id"],
             identity=system_identity,
             extra_filter=dsl.Q("term", request_id=request["id"]),
         )

--- a/invenio_requests/resources/events/config.py
+++ b/invenio_requests/resources/events/config.py
@@ -10,8 +10,17 @@
 
 """RequestEvent Resource Configuration."""
 
-from invenio_records_resources.resources import RecordResourceConfig
+from invenio_records_resources.resources import (
+    RecordResourceConfig,
+    SearchRequestArgsSchema,
+)
 from marshmallow import fields
+
+
+class RequestCommentsSearchRequestArgsSchema(SearchRequestArgsSchema):
+    """Add parameter to parse tags."""
+
+    focus_event_id = fields.UUID()
 
 
 class RequestCommentsResourceConfig(RecordResourceConfig):
@@ -23,6 +32,7 @@ class RequestCommentsResourceConfig(RecordResourceConfig):
         "list": "/<request_id>/comments",
         "item": "/<request_id>/comments/<comment_id>",
         "timeline": "/<request_id>/timeline",
+        "timeline_focused": "/<request_id>/timeline_focused",
     }
 
     # Input
@@ -36,6 +46,8 @@ class RequestCommentsResourceConfig(RecordResourceConfig):
         "request_id": fields.Str(),
         "comment_id": fields.Str(),
     }
+
+    request_search_args = RequestCommentsSearchRequestArgsSchema
 
     response_handlers = {
         "application/vnd.inveniordm.v1+json": RecordResourceConfig.response_handlers[

--- a/invenio_requests/resources/events/resource.py
+++ b/invenio_requests/resources/events/resource.py
@@ -61,6 +61,7 @@ class RequestCommentsResource(RecordResource):
             route("PUT", routes["item"], self.update),
             route("DELETE", routes["item"], self.delete),
             route("GET", routes["timeline"], self.search),
+            route("GET", routes["timeline_focused"], self.focused_list),
         ]
 
     @list_view_args_parser
@@ -135,6 +136,22 @@ class RequestCommentsResource(RecordResource):
             identity=g.identity,
             request_id=resource_requestctx.view_args["request_id"],
             params=resource_requestctx.args,
+            search_preference=search_preference(),
+            expand=resource_requestctx.args.get("expand", False),
+        )
+        return hits.to_dict(), 200
+
+    @list_view_args_parser
+    @request_extra_args
+    @search_args_parser
+    @response_handler(many=True)
+    def focused_list(self):
+        """List the page containing the event with ID focus_event_id, or the first page of results if this is not found."""
+        hits = self.service.focused_list(
+            identity=g.identity,
+            request_id=resource_requestctx.view_args["request_id"],
+            focus_event_id=resource_requestctx.args.get("focus_event_id"),
+            page_size=resource_requestctx.args.get("size"),
             search_preference=search_preference(),
             expand=resource_requestctx.args.get("expand", False),
         )

--- a/invenio_requests/services/events/config.py
+++ b/invenio_requests/services/events/config.py
@@ -18,6 +18,10 @@ from invenio_records_resources.services.base.config import ConfiguratorMixin, Fr
 from invenio_records_resources.services.records.links import pagination_links
 from invenio_records_resources.services.records.results import RecordItem, RecordList
 
+from invenio_requests.proxies import (
+    current_request_type_registry,
+)
+
 from ...records.api import Request, RequestEvent
 from ..permissions import PermissionPolicy
 from ..schemas import RequestEventSchema
@@ -67,9 +71,11 @@ class RequestEventLink(Link):
     """Link variables setter for RequestEvent links."""
 
     @staticmethod
-    def vars(record, vars):
+    def vars(obj, vars):
         """Variables for the URI template."""
-        vars.update({"id": record.id, "request_id": record.request_id})
+        request_type = current_request_type_registry.lookup(vars["request_type"])
+        vars.update({"id": obj.id, "request_id": obj.request_id})
+        vars.update(request_type._update_link_config(**vars))
 
 
 class RequestEventsServiceConfig(RecordServiceConfig, ConfiguratorMixin):
@@ -90,6 +96,7 @@ class RequestEventsServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     # ResultItem configurations
     links_item = {
         "self": RequestEventLink("{+api}/requests/{request_id}/comments/{id}"),
+        "self_html": RequestEventLink("{+ui}/requests/{request_id}#commentevent-{id}"),
     }
     links_search = pagination_links("{+api}/requests/{request_id}/timeline{?args*}")
 

--- a/invenio_requests/services/requests/config.py
+++ b/invenio_requests/services/requests/config.py
@@ -107,6 +107,7 @@ class RequestsServiceConfig(RecordServiceConfig, ConfiguratorMixin):
         "self_html": RequestLink("{+ui}/requests/{id}"),
         "comments": RequestLink("{+api}/requests/{id}/comments"),
         "timeline": RequestLink("{+api}/requests/{id}/timeline"),
+        "timeline_focused": RequestLink("{+api}/requests/{id}/timeline_focused"),
     }
     links_search = pagination_links("{+api}/requests{?args*}")
     links_user_requests_search = pagination_links("{+api}/user/requests{?args*}")

--- a/tests/resources/events/test_request_events_resources.py
+++ b/tests/resources/events/test_request_events_resources.py
@@ -54,6 +54,7 @@ def test_simple_comment_flow(
         "id": comment_id,
         "links": {
             "self": f"https://127.0.0.1:5000/api/requests/{request_id}/comments/{comment_id}",  # noqa
+            "self_html": f"https://127.0.0.1:5000/requests/{request_id}#commentevent-{comment_id}",
             # "report": ""  # TODO
         },
         "permissions": {"can_update_comment": True, "can_delete_comment": True},
@@ -97,6 +98,7 @@ def test_simple_comment_flow(
         "id": comment_id,
         "links": {
             "self": f"https://127.0.0.1:5000/api/requests/{request_id}/comments/{comment_id}",  # noqa
+            "self_html": f"https://127.0.0.1:5000/requests/{request_id}#commentevent-{comment_id}",
             # "report": ""  # TODO
         },
         "permissions": {"can_update_comment": True, "can_delete_comment": True},
@@ -158,7 +160,7 @@ def test_timeline_links(
 
     expected_links = {
         # NOTE: Variations are covered in records-resources
-        "self": f"https://127.0.0.1:5000/api/requests/{request_id}/timeline?page=1&size=25&sort=oldest"  # noqa
+        "self": f"https://127.0.0.1:5000/api/requests/{request_id}/timeline?page=1&size=25&sort=oldest",  # noqa
     }
     assert expected_links == search_record_links
 

--- a/tests/resources/requests/test_requests_resources.py
+++ b/tests/resources/requests/test_requests_resources.py
@@ -153,6 +153,7 @@ def test_simple_request_flow(app, client_logged_as, headers, example_request):
             "self": f"https://127.0.0.1:5000/api/requests/{id_}",
             "self_html": f"https://127.0.0.1:5000/requests/{id_}",
             "timeline": f"https://127.0.0.1:5000/api/requests/{id_}/timeline",
+            "timeline_focused": f"https://127.0.0.1:5000/api/requests/{id_}/timeline_focused",
             "comments": f"https://127.0.0.1:5000/api/requests/{id_}/comments",
             "actions": {
                 "submit": f"https://127.0.0.1:5000/api/requests/{id_}/actions/submit",
@@ -175,6 +176,7 @@ def test_simple_request_flow(app, client_logged_as, headers, example_request):
                 "self": f"https://127.0.0.1:5000/api/requests/{id_}",
                 "self_html": f"https://127.0.0.1:5000/requests/{id_}",
                 "timeline": f"https://127.0.0.1:5000/api/requests/{id_}/timeline",
+                "timeline_focused": f"https://127.0.0.1:5000/api/requests/{id_}/timeline_focused",
                 "comments": f"https://127.0.0.1:5000/api/requests/{id_}/comments",
                 "actions": {
                     "cancel": f"https://127.0.0.1:5000/api/requests/{id_}/actions/cancel",  # noqa
@@ -197,6 +199,7 @@ def test_simple_request_flow(app, client_logged_as, headers, example_request):
                 "self": f"https://127.0.0.1:5000/api/requests/{id_}",
                 "self_html": f"https://127.0.0.1:5000/requests/{id_}",
                 "timeline": f"https://127.0.0.1:5000/api/requests/{id_}/timeline",
+                "timeline_focused": f"https://127.0.0.1:5000/api/requests/{id_}/timeline_focused",
                 "comments": f"https://127.0.0.1:5000/api/requests/{id_}/comments",
                 "actions": {},
             },


### PR DESCRIPTION
Closes #494 

---

* Added a "Copy link" button to events/comments in the UI, which copies the current URL with a hash containing the event ID.
* When TimelineFeed is mounted, it sees if there's a relevant hash in the URL, and requests the server to return the page that contains that event (instead of just requesting the first page).
* Added an argument to the request event `search` route to return the page containing a given event instead of a specific numbered page. The actual page number chosen is returned by the server (see https://github.com/inveniosoftware/invenio-records-resources/pull/656). This is calculated by counting the number of records older than the specified one and dividing by the page size.

## Screenshots

<img width="770" height="241" alt="image" src="https://github.com/user-attachments/assets/a56ccc0a-4cff-4cee-8bea-ffd8b0b1f74c" />

This copies the following link:

```
https://127.0.0.1:5000/communities/pal/requests/8642288d-5938-4eb7-a435-728d7266aa09#commentevent-03a3b14c-1f52-46fd-a60a-5b00ceefd7a6
```

And shows up like this when navigated to:

<img width="573" height="207" alt="image" src="https://github.com/user-attachments/assets/67d5a567-5af6-4847-bfda-d9a77e697f75" />
