### PR TITLE
feat(events): quote comments in replies

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/components/TimelineEventBody.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/components/TimelineEventBody.js
@@ -4,20 +4,96 @@
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
+import { Button, Popup } from "semantic-ui-react";
+import { i18next } from "@translations/invenio_requests/i18next";
 
-export const TimelineEventBody = ({ content, format }) => {
-  return format === "html" ? (
-    <span dangerouslySetInnerHTML={{ __html: content }} />
-  ) : (
-    content
+export const TimelineEventBody = ({ content, format, quote }) => {
+  const ref = useRef(null);
+  const [selectionRange, setSelectionRange] = useState(null);
+
+  useEffect(() => {
+    if (ref.current === null) return;
+
+    const onSelectionChange = () => {
+      const selection = window.getSelection();
+
+      // anchorNode is where the user started dragging the mouse,
+      // focusNode is where they finished. We make sure both nodes
+      // are contained by the ref so we are sure that 100% of the selection
+      // is within this comment event.
+      const selectionIsContainedByRef =
+        ref.current.contains(selection.anchorNode) &&
+        ref.current.contains(selection.focusNode);
+
+      if (
+        !selectionIsContainedByRef ||
+        selection.rangeCount === 0 ||
+        // A "Caret" type e.g. should not trigger a tooltip
+        selection.type !== "Range"
+      ) {
+        setSelectionRange(null);
+        return;
+      }
+
+      setSelectionRange(selection.getRangeAt(0));
+    };
+
+    document.addEventListener("selectionchange", onSelectionChange);
+    return () => document.removeEventListener("selectionchange", onSelectionChange);
+  }, [ref]);
+
+  const tooltipOffset = useMemo(() => {
+    if (!selectionRange) return null;
+
+    const selectionRect = selectionRange.getBoundingClientRect();
+    const refRect = ref.current.getBoundingClientRect();
+
+    // Offset set as [x, y] from the reference position.
+    // E.g. `top left` is relative to [0,0] but `top center` is relative to [{center}, 0]
+    return [selectionRect.x - refRect.x, -(selectionRect.y - refRect.y)];
+  }, [selectionRange]);
+
+  const onQuoteClick = useCallback(() => {
+    if (!selectionRange) return;
+    quote(selectionRange.toString());
+    window.getSelection().removeAllRanges();
+  }, [selectionRange, quote]);
+
+  return (
+    <Popup
+      eventsEnabled={false}
+      open={!!tooltipOffset}
+      offset={tooltipOffset}
+      position="top left"
+      className="requests-event-body-popup"
+      trigger={
+        <span ref={ref}>
+          {format === "html" ? (
+            <span dangerouslySetInnerHTML={{ __html: content }} />
+          ) : (
+            content
+          )}
+        </span>
+      }
+      basic
+    >
+      <Button
+        onClick={onQuoteClick}
+        icon="quote left"
+        content={i18next.t("Quote")}
+        size="small"
+        basic
+      />
+    </Popup>
   );
 };
 
 TimelineEventBody.propTypes = {
   content: PropTypes.string,
   format: PropTypes.string,
+  quote: PropTypes.func.isRequired,
 };
 
 TimelineEventBody.defaultProps = {

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
@@ -5,7 +5,7 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import { RichEditor } from "react-invenio-forms";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { SaveButton } from "../components/Buttons";
 import { Container, Message } from "semantic-ui-react";
 import PropTypes from "prop-types";
@@ -18,6 +18,7 @@ const TimelineCommentEditor = ({
   storedCommentContent,
   restoreCommentContent,
   setCommentContent,
+  appendedCommentContent,
   error,
   submitComment,
   userAvatar,
@@ -25,6 +26,16 @@ const TimelineCommentEditor = ({
   useEffect(() => {
     restoreCommentContent();
   }, [restoreCommentContent]);
+
+  const editorRef = useRef(null);
+  useEffect(() => {
+    if (!appendedCommentContent || !editorRef.current) return;
+    // Move the caret to the end of the body and focus the editor.
+    // See https://www.tiny.cloud/blog/set-and-get-cursor-position/#h_48266906174501699933284256
+    editorRef.current.selection.select(editorRef.current.getBody(), true);
+    editorRef.current.selection.collapse(false);
+    editorRef.current.focus();
+  }, [appendedCommentContent]);
 
   return (
     <div className="timeline-comment-editor-container">
@@ -39,10 +50,11 @@ const TimelineCommentEditor = ({
             inputValue={commentContent}
             // initialValue is not allowed to change, so we use `storedCommentContent` which is set at most once
             initialValue={storedCommentContent}
-            onEditorChange={(event, editor) => {
+            onEditorChange={(_, editor) => {
               setCommentContent(editor.getContent());
             }}
             minHeight={150}
+            onInit={(_, editor) => (editorRef.current = editor)}
           />
         </Container>
       </div>
@@ -62,6 +74,7 @@ const TimelineCommentEditor = ({
 TimelineCommentEditor.propTypes = {
   commentContent: PropTypes.string,
   storedCommentContent: PropTypes.string,
+  appendedCommentContent: PropTypes.string,
   isLoading: PropTypes.bool,
   setCommentContent: PropTypes.func.isRequired,
   error: PropTypes.string,
@@ -73,6 +86,7 @@ TimelineCommentEditor.propTypes = {
 TimelineCommentEditor.defaultProps = {
   commentContent: "",
   storedCommentContent: null,
+  appendedCommentContent: "",
   isLoading: false,
   error: "",
   userAvatar: "",

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/index.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/index.js
@@ -19,6 +19,7 @@ const mapStateToProps = (state) => ({
   error: state.timelineCommentEditor.error,
   commentContent: state.timelineCommentEditor.commentContent,
   storedCommentContent: state.timelineCommentEditor.storedCommentContent,
+  appendedCommentContent: state.timelineCommentEditor.appendedCommentContent,
 });
 
 export const TimelineCommentEditor = connect(

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/actions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/actions.js
@@ -18,6 +18,7 @@ export const HAS_ERROR = "eventEditor/HAS_ERROR";
 export const SUCCESS = "eventEditor/SUCCESS";
 export const SETTING_CONTENT = "eventEditor/SETTING_CONTENT";
 export const RESTORE_CONTENT = "eventEditor/RESTORE_CONTENT";
+export const APPEND_CONTENT = "eventEditor/APPENDING_CONTENT";
 
 const draftCommentKey = (requestId) => `draft-comment-${requestId}`;
 const setDraftComment = (requestId, content) => {
@@ -65,6 +66,15 @@ export const restoreEventContent = () => {
         payload: savedDraft,
       });
     }
+  };
+};
+
+export const appendEventContent = (content, focus) => {
+  return async (dispatch, getState, config) => {
+    dispatch({
+      type: APPEND_CONTENT,
+      payload: content,
+    });
   };
 };
 

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/reducer.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/reducer.js
@@ -11,6 +11,7 @@ import {
   SUCCESS,
   SETTING_CONTENT,
   RESTORE_CONTENT,
+  APPEND_CONTENT,
 } from "./actions";
 
 const initialState = {
@@ -18,12 +19,21 @@ const initialState = {
   isLoading: false,
   commentContent: "",
   storedCommentContent: null,
+  appendedCommentContent: "",
 };
 
 export const commentEditorReducer = (state = initialState, action) => {
   switch (action.type) {
     case SETTING_CONTENT:
       return { ...state, commentContent: action.payload };
+    case APPEND_CONTENT:
+      return {
+        ...state,
+        commentContent: state.commentContent + action.payload,
+        // We keep track of appended content separately to trigger the focus event only when
+        // text is appended (not when the user is typing).
+        appendedCommentContent: state.appendedCommentContent + action.payload,
+      };
     case IS_LOADING:
       return { ...state, isLoading: true };
     case HAS_ERROR:

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEventControlled/TimelineCommentEventControlled.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEventControlled/TimelineCommentEventControlled.js
@@ -59,6 +59,16 @@ class TimelineCommentEventControlled extends Component {
     openConfirmModal(() => deleteComment({ event }));
   };
 
+  /**
+   * Append a quote of the comment's content to the new comment in the editor.
+   *
+   * @param {string} [text] - The text to quote
+   */
+  quote = (text) => {
+    const { appendCommentContent } = this.props;
+    appendCommentContent(`<blockquote>${text}</blockquote><br />`);
+  };
+
   render() {
     const { event } = this.props;
     const { isLoading, isEditing, error } = this.state;
@@ -69,6 +79,7 @@ class TimelineCommentEventControlled extends Component {
           updateComment={this.updateComment}
           deleteComment={this.deleteComment}
           toggleEditMode={this.toggleEditMode}
+          quote={this.quote}
           isLoading={isLoading}
           isEditing={isEditing}
           error={error}
@@ -83,6 +94,7 @@ TimelineCommentEventControlled.propTypes = {
   event: PropTypes.object.isRequired,
   updateComment: PropTypes.func.isRequired,
   deleteComment: PropTypes.func.isRequired,
+  appendCommentContent: PropTypes.func.isRequired,
   openConfirmModal: PropTypes.func.isRequired,
 };
 

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEventControlled/index.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEventControlled/index.js
@@ -7,10 +7,12 @@
 import EventWithStateComponent from "./TimelineCommentEventControlled";
 import { connect } from "react-redux";
 import { updateComment, deleteComment } from "./state/actions";
+import { appendEventContent } from "../timelineCommentEditor/state/actions";
 
 const mapDispatchToProps = (dispatch) => ({
   updateComment: async (payload) => dispatch(updateComment(payload)),
   deleteComment: async (payload) => dispatch(deleteComment(payload)),
+  appendCommentContent: (content) => dispatch(appendEventContent(content)),
 });
 
 export const TimelineCommentEventControlled = connect(

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
@@ -81,6 +81,7 @@ class TimelineCommentEvent extends Component {
       updateComment,
       deleteComment,
       toggleEditMode,
+      quote,
     } = this.props;
     const { commentContent, isSelected } = this.state;
 
@@ -125,6 +126,9 @@ class TimelineCommentEvent extends Component {
                   aria-label={i18next.t("Actions")}
                 >
                   <Dropdown.Menu>
+                    <Dropdown.Item onClick={() => quote(event.payload.content)}>
+                      {i18next.t("Quote")}
+                    </Dropdown.Item>
                     <Dropdown.Item onClick={() => this.copyLink()}>
                       {i18next.t("Copy link")}
                     </Dropdown.Item>
@@ -165,6 +169,7 @@ class TimelineCommentEvent extends Component {
                     <TimelineEventBody
                       content={event?.payload?.content}
                       format={event?.payload?.format}
+                      quote={quote}
                     />
                   )}
 
@@ -193,6 +198,7 @@ TimelineCommentEvent.propTypes = {
   deleteComment: PropTypes.func.isRequired,
   updateComment: PropTypes.func.isRequired,
   toggleEditMode: PropTypes.func.isRequired,
+  quote: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
   isEditing: PropTypes.bool,
   error: PropTypes.string,


### PR DESCRIPTION
Closes #491 

---

* Added a button in the comment action dropdown to quote that comment's contents in the new comment. When clicked, it appends the comment's contents to the RichEditor (inside a blockquote).

* Added a tooltip that renders above any text highlighted within comments and is dynamically positioned to be in the midpoint of the selection. The tooltip contains a "Quote" button and a "Copy" button. When "Quote" is clicked, it performs the same action as above, but just for the selected portion of text.

* Formatting is only kept in the quote for the first method, due to the complexities of propagating HTML formatting for partial selections.

* The blockquote currently has no real pointer to the quoted comment, and is freely editable by the user.

### Preview

https://github.com/user-attachments/assets/33f2382f-039c-439c-b138-06610e801f1c

### To-do
- [x] Improve appearance of buttons within the tooltip. Maybe make them more streamline with the tooltip container and add an icon.
  - E.g. ChatGPT:  <img width="362" height="111" alt="image" src="https://github.com/user-attachments/assets/93f3e521-08e4-4fb4-affe-be56a8b5a481" />
  - Styles have been added in https://github.com/inveniosoftware/invenio-app-rdm/pull/3246
- [x] Auto-focus and scroll to editor when quote is clicked
  - Implemented by listening to changes to a Redux state variable. This is the most elegant solution I could find. Depends on https://github.com/inveniosoftware/react-invenio-forms/pull/315.
- [x] Ensure correct display when quoting comments with quoted content.
- [x] Discuss if this solution is sufficient for our needs, or if we want some sort of pointer to the quoted comment
  - We will start with this and merge it, then see later if there's any demand for some sort of reference to the quoted comment