### PR TITLE
feat(editor): auto-save drafts

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
@@ -1,11 +1,11 @@
 // This file is part of InvenioRequests
-// Copyright (C) 2022 CERN.
+// Copyright (C) 2022-2025 CERN.
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import { RichEditor } from "react-invenio-forms";
-import React from "react";
+import React, { useEffect } from "react";
 import { SaveButton } from "../components/Buttons";
 import { Container, Message } from "semantic-ui-react";
 import PropTypes from "prop-types";
@@ -15,11 +15,17 @@ import { RequestEventAvatarContainer } from "../components/RequestsFeed";
 const TimelineCommentEditor = ({
   isLoading,
   commentContent,
+  storedCommentContent,
+  restoreCommentContent,
   setCommentContent,
   error,
   submitComment,
   userAvatar,
 }) => {
+  useEffect(() => {
+    restoreCommentContent();
+  }, [restoreCommentContent]);
+
   return (
     <div className="timeline-comment-editor-container">
       {error && <Message negative>{error}</Message>}
@@ -31,6 +37,8 @@ const TimelineCommentEditor = ({
         <Container fluid className="ml-0-mobile mr-0-mobile fluid-mobile">
           <RichEditor
             inputValue={commentContent}
+            // initialValue is not allowed to change, so we use `storedCommentContent` which is set at most once
+            initialValue={storedCommentContent}
             onEditorChange={(event, editor) => {
               setCommentContent(editor.getContent());
             }}
@@ -53,15 +61,18 @@ const TimelineCommentEditor = ({
 
 TimelineCommentEditor.propTypes = {
   commentContent: PropTypes.string,
+  storedCommentContent: PropTypes.string,
   isLoading: PropTypes.bool,
   setCommentContent: PropTypes.func.isRequired,
   error: PropTypes.string,
   submitComment: PropTypes.func.isRequired,
+  restoreCommentContent: PropTypes.func.isRequired,
   userAvatar: PropTypes.string,
 };
 
 TimelineCommentEditor.defaultProps = {
   commentContent: "",
+  storedCommentContent: null,
   isLoading: false,
   error: "",
   userAvatar: "",

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/index.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/index.js
@@ -1,22 +1,24 @@
 // This file is part of InvenioRequests
-// Copyright (C) 2022 CERN.
+// Copyright (C) 2022-2025 CERN.
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import { connect } from "react-redux";
-import { submitComment, setEventContent } from "./state/actions";
+import { submitComment, setEventContent, restoreEventContent } from "./state/actions";
 import TimelineCommentEditorComponent from "./TimelineCommentEditor";
 
-const mapDispatchToProps = (dispatch) => ({
-  submitComment: (content, format) => dispatch(submitComment(content, format)),
-  setCommentContent: (content) => dispatch(setEventContent(content)),
-});
+const mapDispatchToProps = {
+  submitComment,
+  setCommentContent: setEventContent,
+  restoreCommentContent: restoreEventContent,
+};
 
 const mapStateToProps = (state) => ({
   isLoading: state.timelineCommentEditor.isLoading,
   error: state.timelineCommentEditor.error,
   commentContent: state.timelineCommentEditor.commentContent,
+  storedCommentContent: state.timelineCommentEditor.storedCommentContent,
 });
 
 export const TimelineCommentEditor = connect(

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/reducer.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/reducer.js
@@ -1,16 +1,23 @@
 // This file is part of InvenioRequests
-// Copyright (C) 2022 CERN.
+// Copyright (C) 2022-2025 CERN.
 // Copyright (C) 2024 KTH Royal Institute of Technology.
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import { IS_LOADING, HAS_ERROR, SUCCESS, SETTING_CONTENT } from "./actions";
+import {
+  IS_LOADING,
+  HAS_ERROR,
+  SUCCESS,
+  SETTING_CONTENT,
+  RESTORE_CONTENT,
+} from "./actions";
 
 const initialState = {
   error: null,
   isLoading: false,
   commentContent: "",
+  storedCommentContent: null,
 };
 
 export const commentEditorReducer = (state = initialState, action) => {
@@ -27,6 +34,13 @@ export const commentEditorReducer = (state = initialState, action) => {
         isLoading: false,
         error: null,
         commentContent: "",
+      };
+    case RESTORE_CONTENT:
+      return {
+        ...state,
+        commentContent: action.payload,
+        // We'll never change this later, so it can be used as an `initialValue`
+        storedCommentContent: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
Closes #493 

---

* Added localStorage hooks to the state actions to save and restore the draft comment

* When the comment is submitted successfully, we delete the local draft. We don't delete if there is an error while saving.

~~**WIP:** When the draft is loaded into the state, TinyMCE doesn't actually display it for some reason. It's definitely being loaded into the state and the editor's props, but it doesn't get further than that.~~

We needed to set `initialValue`, since changes to `value` within the first render cycle are ignored. However, it's important that `initialValue` doesn't change after the first render, as otherwise the entire editor resets every time the user enters some text. So I added a new value in the state to store the value as originally restored from local storage.