### PR TITLE
requests: Add temp _type filter for request search

### DIFF
--- a/invenio_requests/resources/requests/config.py
+++ b/invenio_requests/resources/requests/config.py
@@ -35,6 +35,7 @@ class RequestSearchRequestArgsSchema(SearchRequestArgsSchema):
     receiver = ReferenceString()
     is_open = fields.Boolean()
     shared_with_me = fields.Boolean()
+    _type = fields.List(fields.String())
 
 
 request_error_handlers = {

--- a/invenio_requests/services/requests/config.py
+++ b/invenio_requests/services/requests/config.py
@@ -32,7 +32,12 @@ from .components import (
     RequestReviewersComponent,
 )
 from .links import RequestLink
-from .params import IsOpenParam, ReferenceFilterParam, SharedOrMyRequestsParam
+from .params import (
+    IsOpenParam,
+    ReferenceFilterParam,
+    SharedOrMyRequestsParam,
+    _TypeFilterParam,
+)
 from .results import RequestItem, RequestList
 
 
@@ -53,6 +58,7 @@ class RequestSearchOptions(SearchOptions, SearchOptionsMixin):
         ReferenceFilterParam.factory(param="receiver", field="receiver"),
         ReferenceFilterParam.factory(param="topic", field="topic"),
         IsOpenParam.factory("is_open"),
+        _TypeFilterParam.factory(param="_type", field="type"),
     ]
 
     facets = {

--- a/invenio_requests/services/requests/params.py
+++ b/invenio_requests/services/requests/params.py
@@ -19,6 +19,12 @@ from invenio_search.engine import dsl
 from ...resolvers.registry import ResolverRegistry
 
 
+class _TypeFilterParam(FilterParam):
+    """Filter for _type field."""
+
+    pass
+
+
 class ReferenceFilterParam(FilterParam):
     """Filter for reference dictionaries."""
 


### PR DESCRIPTION
Add a "_type" filter for request search. Since the existing type is only used in faceting, this one is used to fix the filtering so that the total facet numbers are correct if filtered by request.

> [!IMPORTANT]
>  This is intended to be a temporary fix unless we have a better and generic way to implement this, as it would be required for future use cases.

Fixes [3242](https://github.com/inveniosoftware/invenio-app-rdm/issues/3242)