### PR TITLE
feat(editor): add draft save status message

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/components/TimelineDraftSavingStatus.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/components/TimelineDraftSavingStatus.js
@@ -1,0 +1,43 @@
+// This file is part of InvenioRequests
+// Copyright (C) 2025 CERN.
+//
+// Invenio Requests is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+//
+import React from "react";
+import PropTypes from "prop-types";
+import { Message, Icon } from "semantic-ui-react";
+import {
+  DRAFT_STATUS_ERROR,
+  DRAFT_STATUS_SUCCESS,
+} from "../timelineCommentEditor/state/reducer";
+import { i18next } from "@translations/invenio_requests/i18next";
+
+export const TimelineDraftSavingStatus = ({ status }) => {
+  const message =
+    status === DRAFT_STATUS_SUCCESS
+      ? i18next.t("Comment draft saved")
+      : status === DRAFT_STATUS_ERROR
+      ? i18next.t("Comment draft could not be saved")
+      : null;
+
+  if (!message) return null;
+  return (
+    <Message
+      size="tiny"
+      className="mt-0"
+      success={status === DRAFT_STATUS_SUCCESS}
+      negative={status === DRAFT_STATUS_ERROR}
+      compact
+    >
+      <Icon name="check circle" />
+      {message}
+    </Message>
+  );
+};
+
+TimelineDraftSavingStatus.propTypes = {
+  status: PropTypes.string.isRequired,
+};
+
+TimelineDraftSavingStatus.defaultProps = {};

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/TimelineCommentEditor.js
@@ -5,17 +5,19 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import { RichEditor } from "react-invenio-forms";
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { SaveButton } from "../components/Buttons";
 import { Container, Message } from "semantic-ui-react";
 import PropTypes from "prop-types";
 import { i18next } from "@translations/invenio_requests/i18next";
 import { RequestEventAvatarContainer } from "../components/RequestsFeed";
+import { TimelineDraftSavingStatus } from "../components/TimelineDraftSavingStatus";
 
 const TimelineCommentEditor = ({
   isLoading,
   commentContent,
   storedCommentContent,
+  draftSavingStatus,
   restoreCommentContent,
   setCommentContent,
   error,
@@ -26,6 +28,28 @@ const TimelineCommentEditor = ({
     restoreCommentContent();
   }, [restoreCommentContent]);
 
+  const [showDraftStatus, setShowDraftStatus] = useState(false);
+  const [timeoutId, setTimeoutId] = useState(null);
+  // Show a reassuring "draft saved" message after the user stops typing.
+  // In reality, the draft is saved immediately, but this feels more natural.
+  const onEditorChange = useCallback(() => {
+    setShowDraftStatus(false);
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+    const t = setTimeout(() => {
+      setShowDraftStatus(true);
+    }, 500);
+    setTimeoutId(t);
+  }, [timeoutId]);
+
+  // Show "draft saved" if we already loaded a saved draft
+  useEffect(() => {
+    if (storedCommentContent !== null) {
+      setShowDraftStatus(true);
+    }
+  }, [storedCommentContent]);
+
   return (
     <div className="timeline-comment-editor-container">
       {error && <Message negative>{error}</Message>}
@@ -34,16 +58,23 @@ const TimelineCommentEditor = ({
           src={userAvatar}
           className="tablet computer only rel-mr-1"
         />
-        <Container fluid className="ml-0-mobile mr-0-mobile fluid-mobile">
+        <Container
+          fluid
+          className={`ml-0-mobile mr-0-mobile fluid-mobile${
+            showDraftStatus ? " has-draft-status" : ""
+          }`}
+        >
           <RichEditor
             inputValue={commentContent}
             // initialValue is not allowed to change, so we use `storedCommentContent` which is set at most once
             initialValue={storedCommentContent}
             onEditorChange={(event, editor) => {
               setCommentContent(editor.getContent());
+              onEditorChange();
             }}
             minHeight={150}
           />
+          {showDraftStatus && <TimelineDraftSavingStatus status={draftSavingStatus} />}
         </Container>
       </div>
       <div className="text-align-right rel-mt-1">
@@ -62,6 +93,7 @@ const TimelineCommentEditor = ({
 TimelineCommentEditor.propTypes = {
   commentContent: PropTypes.string,
   storedCommentContent: PropTypes.string,
+  draftSavingStatus: PropTypes.string.isRequired,
   isLoading: PropTypes.bool,
   setCommentContent: PropTypes.func.isRequired,
   error: PropTypes.string,

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/index.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/index.js
@@ -19,6 +19,7 @@ const mapStateToProps = (state) => ({
   error: state.timelineCommentEditor.error,
   commentContent: state.timelineCommentEditor.commentContent,
   storedCommentContent: state.timelineCommentEditor.storedCommentContent,
+  draftSavingStatus: state.timelineCommentEditor.draftSavingStatus,
 });
 
 export const TimelineCommentEditor = connect(

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/actions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/actions.js
@@ -18,6 +18,8 @@ export const HAS_ERROR = "eventEditor/HAS_ERROR";
 export const SUCCESS = "eventEditor/SUCCESS";
 export const SETTING_CONTENT = "eventEditor/SETTING_CONTENT";
 export const RESTORE_CONTENT = "eventEditor/RESTORE_CONTENT";
+export const DRAFT_SAVED = "eventEditor/DRAFT_SAVED";
+export const DRAFT_SAVE_ERROR = "eventEditor/DRAFT_SAVE_ERROR";
 
 const draftCommentKey = (requestId) => `draft-comment-${requestId}`;
 const setDraftComment = (requestId, content) => {
@@ -40,11 +42,15 @@ export const setEventContent = (content) => {
 
     try {
       setDraftComment(request.data.id, content);
+      dispatch({ type: DRAFT_SAVED });
     } catch (e) {
       // This should not be a fatal error. The comment editor is still usable if
       // draft saving isn't working (e.g. on very old browsers or ultra-restricted
       // environments with 0 storage quota.)
-      console.warn("Failed to save comment:", e);
+      console.warn("Failed to save comment draft:", e);
+      // Local Storage errors are ambiguous and heavily browser-dependent so showing the
+      // specific error message in the UI would not be helpful.
+      dispatch({ type: DRAFT_SAVE_ERROR });
     }
   };
 };
@@ -56,7 +62,7 @@ export const restoreEventContent = () => {
     try {
       savedDraft = getDraftComment(request.data.id);
     } catch (e) {
-      console.warn("Failed to get saved comment:", e);
+      console.warn("Failed to get saved comment draft:", e);
     }
 
     if (savedDraft) {
@@ -100,7 +106,7 @@ export const submitComment = (content, format) => {
       try {
         deleteDraftComment(request.data.id);
       } catch (e) {
-        console.warn("Failed to delete saved comment:", e);
+        console.warn("Failed to delete saved comment draft:", e);
       }
 
       await dispatch({

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/reducer.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineCommentEditor/state/reducer.js
@@ -11,13 +11,20 @@ import {
   SUCCESS,
   SETTING_CONTENT,
   RESTORE_CONTENT,
+  DRAFT_SAVED,
+  DRAFT_SAVE_ERROR,
 } from "./actions";
+
+export const DRAFT_STATUS_SUCCESS = "success";
+export const DRAFT_STATUS_ERROR = "failure";
+export const DRAFT_STATUS_NONE = "none";
 
 const initialState = {
   error: null,
   isLoading: false,
   commentContent: "",
   storedCommentContent: null,
+  draftSavingStatus: DRAFT_STATUS_NONE,
 };
 
 export const commentEditorReducer = (state = initialState, action) => {
@@ -34,6 +41,7 @@ export const commentEditorReducer = (state = initialState, action) => {
         isLoading: false,
         error: null,
         commentContent: "",
+        draftSavingStatus: DRAFT_STATUS_NONE,
       };
     case RESTORE_CONTENT:
       return {
@@ -41,6 +49,17 @@ export const commentEditorReducer = (state = initialState, action) => {
         commentContent: action.payload,
         // We'll never change this later, so it can be used as an `initialValue`
         storedCommentContent: action.payload,
+        draftSavingStatus: DRAFT_STATUS_SUCCESS,
+      };
+    case DRAFT_SAVED:
+      return {
+        ...state,
+        draftSavingStatus: DRAFT_STATUS_SUCCESS,
+      };
+    case DRAFT_SAVE_ERROR:
+      return {
+        ...state,
+        draftSavingStatus: DRAFT_STATUS_ERROR,
       };
     default:
       return state;


### PR DESCRIPTION
Closes #493

---

* Added a message to show the status of the draft saving. To give a more natural feel, it shows up 500ms after the last input from the user (but the draft is actually saved immediately).
* See https://github.com/inveniosoftware/invenio-app-rdm/pull/3245 for CSS changes


https://github.com/user-attachments/assets/f9b2c734-53c1-437e-aa61-549d056bcf6d

On mobile:

<img width="435" height="336" alt="image" src="https://github.com/user-attachments/assets/db0c877b-a4ad-4773-9e0e-dd076abd3df8" />
