### PR TITLE
fix: event entrypoint incorrectly pointed to request type registry

### DIFF
--- a/invenio_requests/ext.py
+++ b/invenio_requests/ext.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2021 Northwestern University.
 # Copyright (C) 2021 TU Wien.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2025 CESNET i.a.l.e.
 #
 # Invenio-Requests is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -108,7 +109,7 @@ class InvenioRequests:
         register_entry_point(
             self.request_type_registry, "invenio_requests.types", app=app
         )
-        register_entry_point(self.request_type_registry, "invenio_requests.event_types")
+        register_entry_point(self.event_type_registry, "invenio_requests.event_types")
         register_entry_point(
             self.entity_resolvers_registry, "invenio_requests.entity_resolvers"
         )

--- a/tests/mock_module/__init__.py
+++ b/tests/mock_module/__init__.py
@@ -1,8 +1,31 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2025 Northwestern University.
+# Copyright (C) 2025 CESNET i.a.l.e.
 #
 # Invenio-Requests is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Mock module."""
+"""Mock module for registry tests."""
+
+from invenio_users_resources.entity_resolvers import UserResolver
+
+from invenio_requests.customizations import EventType, RequestType
+
+
+class MockRequestType(RequestType):
+    """Mock request type."""
+
+    type_id = "mock"
+
+
+class MockEventType(EventType):
+    """Mock event type."""
+
+    type_id = "M"
+
+
+class MockResolver(UserResolver):
+    """Mock entity resolver."""
+
+    type_id = "mock"

--- a/tests/registry/conftest.py
+++ b/tests/registry/conftest.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 CESNET i.a.l.e.
+#
+# Invenio-Requests is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""App fixture with test entrypoints."""
+
+import pytest
+from invenio_app.factory import create_api
+
+
+@pytest.fixture(scope="module")
+def create_app(instance_path, entry_points):
+    """Application factory fixture."""
+    return create_api
+
+
+@pytest.fixture(scope="module")
+def extra_entry_points():
+    """Extra entry points to load the mock_module features."""
+    return {
+        "invenio_requests.types": [
+            "mock_module = tests.mock_module:MockRequestType",
+        ],
+        "invenio_requests.event_types": [
+            "mock_module = tests.mock_module:MockEventType",
+        ],
+        "invenio_requests.entity_resolvers": [
+            "mock_module = tests.mock_module:MockResolver",
+        ],
+    }

--- a/tests/registry/test_registries.py
+++ b/tests/registry/test_registries.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 CESNET i.a.l.e.
+#
+# Invenio-Requests is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test for entrypoint loading."""
+
+from tests.mock_module import MockEventType, MockRequestType, MockResolver
+
+
+def test_request_type_registry_entrypoints(app):
+    registry = app.extensions["invenio-requests"].request_type_registry
+    assert isinstance(registry.lookup("mock"), MockRequestType)
+
+
+def test_event_type_registry_entrypoints(app):
+    registry = app.extensions["invenio-requests"].event_type_registry
+    assert isinstance(registry.lookup("M"), MockEventType)
+
+
+def test_entity_resolvers_registry_entrypoints(app):
+    registry = app.extensions["invenio-requests"].entity_resolvers_registry
+    assert isinstance(registry.lookup("mock"), MockResolver)


### PR DESCRIPTION
### Description

During initialization of invenio_requests request types, event types and entity references are loaded from entrypoints to the respective registries. There was a copypaste error in `init_registry` that caused that event type entrypoints were loaded incorrectly into request type registry. This patch fixes it by using the correct registry.

Tests were added to show that all entrypoints are loaded correctly.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
