### PR TITLE
fix(request-metadata): missing record link

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js
@@ -234,15 +234,17 @@ class RequestMetadata extends Component {
             </>
           )}
 
-          {request.topic?.record && request.type !== "community-submission" && (
-            <>
-              <Divider />
-              <Header as="h3" size="tiny">
-                {i18next.t("Record")}
-              </Header>
-              <a href={`/records/${request.topic.record}`}>{request.title}</a>
-            </>
-          )}
+          {request.topic?.record &&
+            (request.type !== "community-submission" ||
+              request.status === "accepted") && (
+              <>
+                <Divider />
+                <Header as="h3" size="tiny">
+                  {i18next.t("Record")}
+                </Header>
+                <a href={`/records/${request.topic.record}`}>{request.title}</a>
+              </>
+            )}
           {permissions.can_lock_request && <LockRequest request={request} />}
         </>
       </Overridable>


### PR DESCRIPTION
* Record link was disabled for community submission requests, because the record doesn't exist before the request is successfully accepted.

* Added a check to allow the link to be shown once the request is closed and successful.
