### PR TITLE
chore: black 26.1.0 formatting

### DIFF
--- a/invenio_requests/customizations/states.py
+++ b/invenio_requests/customizations/states.py
@@ -7,7 +7,6 @@
 
 """Enum for the various open states a request can have."""
 
-
 from enum import Enum
 
 

--- a/invenio_requests/records/dumpers/granttokens.py
+++ b/invenio_requests/records/dumpers/granttokens.py
@@ -7,7 +7,6 @@
 
 """Dumps entity grant tokens into the indexed request record."""
 
-
 from invenio_records.dumpers import SearchDumperExt
 from invenio_records_resources.references import EntityGrant
 

--- a/invenio_requests/records/systemfields/expired_state.py
+++ b/invenio_requests/records/systemfields/expired_state.py
@@ -7,7 +7,6 @@
 
 """Systemfield for calculating the ``is_expired`` property of a request."""
 
-
 from datetime import datetime
 
 import pytz

--- a/invenio_requests/resources/requests/config.py
+++ b/invenio_requests/resources/requests/config.py
@@ -10,7 +10,6 @@
 
 """Requests resource config."""
 
-
 import marshmallow as ma
 from flask_resources import HTTPJSONException, create_error_handler
 from invenio_records_resources.resources import (

--- a/invenio_requests/resources/requests/resource.py
+++ b/invenio_requests/resources/requests/resource.py
@@ -9,7 +9,6 @@
 
 """Requests resource."""
 
-
 from flask import g
 from flask_resources import resource_requestctx, response_handler, route
 from invenio_records_resources.resources import RecordResource

--- a/invenio_requests/services/requests/params.py
+++ b/invenio_requests/services/requests/params.py
@@ -7,6 +7,7 @@
 # details.
 
 """Search parameter interpreters for requests."""
+
 from functools import partial
 
 from invenio_records_resources.references import EntityGrant

--- a/invenio_requests/services/user_moderation/errors.py
+++ b/invenio_requests/services/user_moderation/errors.py
@@ -5,6 +5,7 @@
 # Invenio-Requests is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 """User moderation requests service errors."""
+
 from invenio_i18n import lazy_gettext as _
 
 

--- a/invenio_requests/services/user_moderation/service.py
+++ b/invenio_requests/services/user_moderation/service.py
@@ -5,6 +5,7 @@
 # Invenio-Requests is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 """User moderation service."""
+
 from flask import current_app
 from invenio_accounts.models import Role
 from invenio_i18n import gettext as _

--- a/tests/services/events/test_request_events_service.py
+++ b/tests/services/events/test_request_events_service.py
@@ -9,6 +9,7 @@
 # details.
 
 """Service tests."""
+
 import copy
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
Compatible with the `black` version used with Python 3.11 and 3.14