### PR TITLE
fix using default imports so overrides would work

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/InvenioRequestsApp.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/InvenioRequestsApp.js
@@ -11,7 +11,7 @@ import {
   InvenioRequestEventsApi,
   RequestEventsLinksExtractor,
 } from "./api";
-import { Request } from "./request";
+import Request from "./request";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { configureStore } from "./store";

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
@@ -8,7 +8,7 @@
 import { RequestLinksExtractor } from "../../api";
 import React from "react";
 import Overridable from "react-overridable";
-import { RequestAction } from "./RequestAction";
+import RequestAction from "./RequestAction";
 import { Dropdown } from "semantic-ui-react";
 import { AppMedia } from "@js/invenio_theme/Media";
 import PropTypes from "prop-types";

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/TimelineFeed.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timeline/TimelineFeed.js
@@ -15,7 +15,7 @@ import Loader from "../components/Loader";
 import { DeleteConfirmationModal } from "../components/modals/DeleteConfirmationModal";
 import RequestsFeed from "../components/RequestsFeed";
 import { TimelineCommentEditor } from "../timelineCommentEditor";
-import { TimelineCommentEventControlled } from "../timelineCommentEventControlled";
+import TimelineCommentEventControlled from "../timelineCommentEventControlled";
 import { getEventIdFromUrl } from "../timelineEvents/utils";
 import LoadMore from "./LoadMore";
 import TimelineEventPlaceholder from "../components/TimelineEventPlaceholder";

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/timelineEvents/TimelineCommentEvent.js
@@ -18,7 +18,7 @@ import { TimelineEventBody } from "../components/TimelineEventBody";
 import { toRelativeTime } from "react-invenio-forms";
 import { isEventSelected } from "./utils";
 import { RequestEventsLinksExtractor } from "../api/InvenioRequestEventsApi.js";
-import { TimelineCommentReplies } from "../timelineCommentReplies/index.js";
+import TimelineCommentReplies from "../timelineCommentReplies/index.js";
 
 class TimelineCommentEvent extends Component {
   constructor(props) {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Certain components i.e. https://github.com/inveniosoftware/invenio-requests/blob/f953d8c1bdcf51f751670168f94995e0fb4cfc8e/invenio_requests/assets/semantic-ui/js/invenio_requests/request/Request.js#L57

Export Overridable component as a default, but then later other components, import the named export from that module and in that way, you are no longer able to override this entire component. This fix uses correct default import from the component, so that it can be overriden. Please take a look.


