### PR TITLE
feat: introduced SameAs to make the policy extendable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@
 Changes
 =======
 
+Version v13.0.0 (released 2026-05-29)
+
+- chore(setup): bump dependencies
+- feat: introduced SameAs to make the policy extendable
+- feat: Extra context for permission checks
+
 Version v12.6.2 (released 2026-05-22)
 
 - fix(comments): null ref for deleted comments

--- a/invenio_requests/__init__.py
+++ b/invenio_requests/__init__.py
@@ -21,7 +21,7 @@ from .proxies import (
     current_requests_service,
 )
 
-__version__ = "12.6.2"
+__version__ = "13.0.0"
 
 __all__ = (
     "__version__",

--- a/invenio_requests/services/permissions.py
+++ b/invenio_requests/services/permissions.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2021 Northwestern University.
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2026 CESNET, z.s.p.o.
 #
 # Invenio-Requests is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -17,6 +18,7 @@ from invenio_records_permissions.generators import (
     AuthenticatedUser,
     Disable,
     IfConfig,
+    SameAs,
     SystemProcess,
     SystemProcessWithoutSuperUser,
 )
@@ -32,7 +34,7 @@ class PermissionPolicy(RecordPermissionPolicy):
     # Just about ability to perform a search (not what requests you can access)
     can_search = [AuthenticatedUser(), SystemProcess()]
 
-    can_search_user_requests = can_search
+    can_search_user_requests = SameAs("can_search")
 
     # Read/update/delete action deals with requests in **multiple states**, and
     # thus must take the request status into account.
@@ -76,13 +78,13 @@ class PermissionPolicy(RecordPermissionPolicy):
     # with requests in a **single state** and thus doesn't need to take the
     # request status into account.
     can_action_submit = [Creator(), SystemProcess()]
-    can_action_cancel = [Creator(), SystemProcess()]
+    can_action_cancel = SameAs("can_action_submit")
     # `SystemProcessWithoutSuperUser`: expire is an automatic action done only by
     # the system, therefore the `superuser-action` must be explicitly excluded
     # as it's added by default to any permission.
     can_action_expire = [SystemProcessWithoutSuperUser()]
     can_action_accept = [Receiver(), SystemProcess()]
-    can_action_decline = [Receiver(), SystemProcess()]
+    can_action_decline = SameAs("can_action_accept")
 
     can_lock_request = [
         IfConfig(
@@ -115,16 +117,16 @@ class PermissionPolicy(RecordPermissionPolicy):
             then_=[
                 IfLocked(
                     then_=[Administration()],
-                    else_=can_read,
+                    else_=SameAs("can_read"),
                 ),
                 SystemProcess(),
             ],
-            else_=can_read,
+            else_=SameAs("can_read"),
         ),
     ]
 
     # If you can create a comment, you can reply to a comment.
-    can_reply_comment = can_create_comment
+    can_reply_comment = SameAs("can_create_comment")
 
     # Needed by the search events permission because a permission_action must
     # be provided to create_search(), but the event search is already protected

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,9 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-records-resources>=9.2.0,<10.0.0
+    invenio-records-resources>=10.0.0,<11.0.0
     invenio-theme>=4.0.0,<5.0.0
-    invenio-users-resources>=10.0.0,<11.0.0
+    invenio-users-resources>=11.0.0,<12.0.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
### Description

This PR applies SameAs to the requests permission policy to change the static binding to dynamic. Please see https://github.com/inveniosoftware/invenio-records-permissions/pull/119 for rationale and more details.

> [!CAUTION]
> Locally, I've got a flipping test `test_reply_request_event_notification` both with and without this change.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
