### PR TITLE
fix(tests): passing expires_at as datetime, not as string

### DIFF
--- a/tests/services/requests/test_requests_tasks.py
+++ b/tests/services/requests/test_requests_tasks.py
@@ -24,9 +24,7 @@ def test_check_expired_requests(
     now = datetime.now(timezone.utc).replace(tzinfo=None)
 
     # created only should not be picked up
-    created_request = create_request(
-        identity=identity_simple, expires_at=now.isoformat()
-    )
+    created_request = create_request(identity=identity_simple, expires_at=now)
     Request.index.refresh()
     check_expired_requests()
     Request.index.refresh()
@@ -58,9 +56,7 @@ def test_check_expired_requests(
     assert request_list.total == 0
 
     # expiry date in future should not be touched
-    s2 = submit_request(
-        identity_simple, expires_at=(now + timedelta(days=1)).isoformat()
-    )
+    s2 = submit_request(identity_simple, expires_at=now + timedelta(days=1))
     Request.index.refresh()
     check_expired_requests()
     Request.index.refresh()
@@ -75,7 +71,7 @@ def test_check_expired_requests(
     )
     assert request_list.total == 0
 
-    s3 = submit_request(identity_simple, expires_at=now.isoformat())
+    s3 = submit_request(identity_simple, expires_at=now)
     Request.index.refresh()
     check_expired_requests()
     Request.index.refresh()


### PR DESCRIPTION
### Description

Caused by https://github.com/inveniosoftware/invenio-db/pull/200 , though independent on it

The implementation of this module contains the correct conversion between string representation of the date on the REST level and the datetime representation on the model level.

Only tests that directly create the db model had to be changed to consistently use datetimes.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
