### PR TITLE
Static request actions

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActionModal.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActionModal.js
@@ -40,17 +40,17 @@ export class RequestActionModal extends Component {
 
     const currentModalOpen = modalOpen[modalId];
 
-    const available_actions = {
-      "create": i18next.t("create"),
-      "submit": i18next.t("submit"),
-      "delete": i18next.t("delete"),
-      "accept": i18next.t("accept"),
-      "decline": i18next.t("decline"),
-      "cancel": i18next.t("cancel"),
-      "expire": i18next.t("expire"),
+    const availableActions = {
+      create: i18next.t("create"),
+      submit: i18next.t("submit"),
+      delete: i18next.t("delete"),
+      accept: i18next.t("accept"),
+      decline: i18next.t("decline"),
+      cancel: i18next.t("cancel"),
+      expire: i18next.t("expire"),
     };
 
-    const actionLabel = available_actions[action] ? available_actions[action] : action;
+    const actionLabel = availableActions[action] ? availableActions[action] : action;
 
     return (
       <Overridable id="InvenioRequests.RequestActionModal.layout" {...this.props}>
@@ -59,7 +59,7 @@ export class RequestActionModal extends Component {
           <Modal aria-label={action} role="dialog" id={modalId} open={currentModalOpen}>
             <Modal.Header as="h2" className="capitalize-first-char">
               <Overridable id={`RequestActionModal.title.${action}`}>
-                <span>{ i18next.t("{{action}} request", {  action: actionLabel }) }</span>
+                <span>{i18next.t("{{action}} request", { action: actionLabel })}</span>
               </Overridable>
             </Modal.Header>
             <Modal.Content>

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActionModal.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActionModal.js
@@ -40,6 +40,18 @@ export class RequestActionModal extends Component {
 
     const currentModalOpen = modalOpen[modalId];
 
+    const available_actions = {
+      "create": i18next.t("create"),
+      "submit": i18next.t("submit"),
+      "delete": i18next.t("delete"),
+      "accept": i18next.t("accept"),
+      "decline": i18next.t("decline"),
+      "cancel": i18next.t("cancel"),
+      "expire": i18next.t("expire"),
+    };
+
+    const actionLabel = available_actions[action] ? available_actions[action] : action;
+
     return (
       <Overridable id="InvenioRequests.RequestActionModal.layout" {...this.props}>
         {/* currentModalOpen prevents mounting multiple instances */}
@@ -47,7 +59,7 @@ export class RequestActionModal extends Component {
           <Modal aria-label={action} role="dialog" id={modalId} open={currentModalOpen}>
             <Modal.Header as="h2" className="capitalize-first-char">
               <Overridable id={`RequestActionModal.title.${action}`}>
-                <span>{ i18next.t("{{action}} request", {  action: i18next.t(action) }) }</span>
+                <span>{ i18next.t("{{action}} request", {  action: actionLabel }) }</span>
               </Overridable>
             </Modal.Header>
             <Modal.Content>

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActionModal.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActionModal.js
@@ -8,7 +8,6 @@
 import { RequestActionContext } from "@js/invenio_requests/request/actions/context";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import { Trans } from "react-i18next";
 import { i18next } from "@translations/invenio_requests/i18next";
 import Overridable from "react-overridable";
 import { Modal } from "semantic-ui-react";
@@ -48,10 +47,7 @@ export class RequestActionModal extends Component {
           <Modal aria-label={action} role="dialog" id={modalId} open={currentModalOpen}>
             <Modal.Header as="h2" className="capitalize-first-char">
               <Overridable id={`RequestActionModal.title.${action}`}>
-                <Trans
-                  defaults="{{action}} request"
-                  values={{ action: i18next.t(action) }}
-                />
+                <span>{ i18next.t("{{action}} request", {  action: i18next.t(action) }) }</span>
               </Overridable>
             </Modal.Header>
             <Modal.Content>

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
@@ -12,8 +12,18 @@ import { RequestAction } from "./RequestAction";
 import { Dropdown } from "semantic-ui-react";
 import { AppMedia } from "@js/invenio_theme/Media";
 import PropTypes from "prop-types";
+import { i18next } from "../../../../translations/invenio_requests/i18next";
 
 export const RequestActions = ({ request, size }) => {
+  const available_actions = [
+    i18next.t("create"),
+    i18next.t("submit"),
+    i18next.t("delete"),
+    i18next.t("accept"),
+    i18next.t("decline"),
+    i18next.t("cancel"),
+    i18next.t("expire"),
+  ];
   const actions = Object.keys(new RequestLinksExtractor(request).actions);
   const { MediaContextProvider, Media } = AppMedia;
 

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
@@ -15,16 +15,9 @@ import PropTypes from "prop-types";
 import { i18next } from "@translations/invenio_requests/i18next";
 
 export const RequestActions = ({ request, size }) => {
-  const available_actions = [
-    i18next.t("create"),
-    i18next.t("submit"),
-    i18next.t("delete"),
-    i18next.t("accept"),
-    i18next.t("decline"),
-    i18next.t("cancel"),
-    i18next.t("expire"),
-  ];
+
   const actions = Object.keys(new RequestLinksExtractor(request).actions);
+
   const { MediaContextProvider, Media } = AppMedia;
 
   return (

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
@@ -12,7 +12,7 @@ import { RequestAction } from "./RequestAction";
 import { Dropdown } from "semantic-ui-react";
 import { AppMedia } from "@js/invenio_theme/Media";
 import PropTypes from "prop-types";
-import { i18next } from "../../../../translations/invenio_requests/i18next";
+import { i18next } from "@translations/invenio_requests/i18next";
 
 export const RequestActions = ({ request, size }) => {
   const available_actions = [

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/actions/RequestActions.js
@@ -12,10 +12,8 @@ import { RequestAction } from "./RequestAction";
 import { Dropdown } from "semantic-ui-react";
 import { AppMedia } from "@js/invenio_theme/Media";
 import PropTypes from "prop-types";
-import { i18next } from "@translations/invenio_requests/i18next";
 
 export const RequestActions = ({ request, size }) => {
-
   const actions = Object.keys(new RequestLinksExtractor(request).actions);
 
   const { MediaContextProvider, Media } = AppMedia;


### PR DESCRIPTION
### Description

As discussed in https://github.com/inveniosoftware/invenio-requests/pull/597 using Trans component is brittle and should be replaced. Available action types should be registered statically somewhere so they can be picked up by i18next for translations.


### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).