### PR TITLE
fix: preserve redirect responses for S3 downloads

### DIFF
--- a/invenio_requests/resources/files/resource.py
+++ b/invenio_requests/resources/files/resource.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2025 CERN.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Requests is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -68,4 +69,4 @@ class RequestFilesResource(RecordResource):
             id_=resource_requestctx.view_args["id"],
             file_key=resource_requestctx.view_args["key"],
         )
-        return file.send_file(as_attachment=True, restricted=True), 200
+        return file.send_file(as_attachment=True, restricted=True)

--- a/invenio_requests/views/files/requests.py
+++ b/invenio_requests/views/files/requests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2025 CERN.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Requests is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -20,4 +21,4 @@ def read_file(pid_value, file_key):
         id_=pid_value,
         file_key=file_key,
     )
-    return file.send_file(as_attachment=True, restricted=True), 200
+    return file.send_file(as_attachment=True, restricted=True)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Preserve the original response returned by `file.send_file()`in both the API
and UI request file endpoints instead of forcing HTTP 200.

This fixes S3 and MinIO-backed request comment attachments where downloads
returned a text file containing the presigned URL instead of redirecting
to the object content. It also fixes inline comment preview paths that rely
on the same file delivery behavior.

What remains:
the rich editor still uses `download_html` for inline file and image insertion.
That behavior lives in `react-invenio-forms` and should be updated separately
to use the content link for preview and inline rendering.

partially closes: https://github.com/inveniosoftware/invenio-app-rdm/issues/3417

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
