### PR TITLE
fix(reviewers): have `payload.event` reflect the actual event type

### DIFF
--- a/invenio_requests/services/requests/components.py
+++ b/invenio_requests/services/requests/components.py
@@ -157,7 +157,7 @@ class RequestReviewersComponent(ServiceComponent):
             if not event_type == "unchanged":
                 event = ReviewersUpdatedType(
                     payload=dict(
-                        event="reviewers_updated",
+                        event=f"reviewers_{event_type}",
                         content=_(f"{event_type} a reviewer"),
                         reviewers=updated_reviewers,
                     )


### PR DESCRIPTION
Previously, `ReviewersUpdatedType` events were always created with `payload.event = "reviewers_updated"`, regardless of the actual event type (added/removed/updated/unchanged).
In this PR, we use the determined event type instead to add more context to the event.