### PR TITLE
fix(comments): null ref for deleted comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
 Changes
 =======
 
+Version v12.6.2 (released 2026-05-22)
+
+- fix(comments): null ref for deleted comments
+
 Version v12.6.1 (released 2026-05-05)
 
 - fix(comments): ensure "show less" button is hidden for comments <200px height

--- a/invenio_requests/__init__.py
+++ b/invenio_requests/__init__.py
@@ -21,7 +21,7 @@ from .proxies import (
     current_requests_service,
 )
 
-__version__ = "12.6.1"
+__version__ = "12.6.2"
 
 __all__ = (
     "__version__",

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/components/TimelineEventBody.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/components/TimelineEventBody.js
@@ -156,9 +156,9 @@ const TimelineEventBodyContainer = ({
   }, []);
 
   useEffect(() => {
-    if (!collapsible) return;
-
     const el = refInner.current;
+    if (!collapsible || !el) return;
+
     if (expanded) {
       // The collapsed comment height is 200px. If the comment is too short to need expanding but `expanded` is true
       // nonetheless, `el.scrollHeight` will still be less than 200, so the comment will not be overflowing.
@@ -175,7 +175,6 @@ const TimelineEventBodyContainer = ({
       setIsOverflowing(el.scrollHeight > el.clientHeight);
     });
 
-    if (!el) return;
     resizeObserver.observe(el);
     return () => {
       resizeObserver.unobserve(el);


### PR DESCRIPTION
* `el` was not defined for deleted comments (which don't use `refInner`), causing a crash if one was being rendered.

* The guard clause was moved up to prevent this.