### PR TITLE
fix(requests-ui): show record version in submission Record link

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js
@@ -162,6 +162,7 @@ class RequestMetadata extends Component {
 
     const expandedCreatedBy = request.expanded?.created_by;
     const expandedReceiver = request.expanded?.receiver;
+    const topicVersion = request.expanded?.topic?.version;
 
     return (
       <Overridable
@@ -249,7 +250,10 @@ class RequestMetadata extends Component {
                 <Header as="h3" size="tiny">
                   {i18next.t("Record")}
                 </Header>
-                <a href={`/records/${request.topic.record}`}>{request.title}</a>
+                <a href={`/records/${request.topic.record}`}>
+                  {request.title}
+                  {topicVersion && ` (${topicVersion})`}
+                </a>
               </>
             )}
           {permissions.can_lock_request && <LockRequest request={request} />}


### PR DESCRIPTION
Fixes inveniosoftware/invenio-rdm-records#2358
Related: https://github.com/inveniosoftware/invenio-rdm-records/pull/2365
:heart: Thank you for your contribution!

### Description

Show the record version in the request sidebar Record link for accepted community submissions (e.g. Test feature (v3)), using expanded.topic.version from the request payload.

<img width="298" height="451" alt="image" src="https://github.com/user-attachments/assets/c5e98690-cc3a-4b5f-8cd5-3c6920c6b3f4" />




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
