### PR TITLE
fix(i18n): update variable naming in  translations

### DIFF
--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/api/InvenioRequestApi.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/api/InvenioRequestApi.js
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2022 CERN.
+ * SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
  * SPDX-License-Identifier: MIT
  */
 
@@ -13,8 +14,8 @@ export class RequestLinksExtractor {
   constructor(request) {
     if (!request?.links) {
       throw TypeError(
-        i18next.t("{{link_name}} links are undefined. Please refresh the page.", {
-          link_name: "Request resource",
+        i18next.t("{{linkName}} links are undefined. Please refresh the page.", {
+          linkName: "Request resource",
         })
       );
     }
@@ -28,8 +29,8 @@ export class RequestLinksExtractor {
   get timeline() {
     if (!this.#urls.timeline) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Timeline",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Timeline",
         })
       );
     }
@@ -39,8 +40,8 @@ export class RequestLinksExtractor {
   get timelineFocused() {
     if (!this.#urls.timeline_focused) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Focused timeline",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Focused timeline",
         })
       );
     }
@@ -50,8 +51,8 @@ export class RequestLinksExtractor {
   get comments() {
     if (!this.#urls.comments) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Comments",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Comments",
         })
       );
     }
@@ -61,8 +62,8 @@ export class RequestLinksExtractor {
   get actions() {
     if (!this.#urls.actions) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Actions",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Actions",
         })
       );
     }

--- a/invenio_requests/assets/semantic-ui/js/invenio_requests/api/InvenioRequestEventsApi.js
+++ b/invenio_requests/assets/semantic-ui/js/invenio_requests/api/InvenioRequestEventsApi.js
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2022 CERN.
+ * SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
  * SPDX-License-Identifier: MIT
  */
 import { http } from "react-invenio-forms";
@@ -15,8 +16,8 @@ export class RequestEventsLinksExtractor {
   get eventUrl() {
     if (!this.#links.self) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Self",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Self",
         })
       );
     }
@@ -26,8 +27,8 @@ export class RequestEventsLinksExtractor {
   get eventHtmlUrl() {
     if (!this.#links.self_html) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Self HTML",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Self HTML",
         })
       );
     }
@@ -37,8 +38,8 @@ export class RequestEventsLinksExtractor {
   get repliesUrl() {
     if (!this.#links.replies) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Replies",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Replies",
         })
       );
     }
@@ -48,8 +49,8 @@ export class RequestEventsLinksExtractor {
   get focusedRepliesUrl() {
     if (!this.#links.replies_focused) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Focused replies",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Focused replies",
         })
       );
     }
@@ -59,8 +60,8 @@ export class RequestEventsLinksExtractor {
   get replyUrl() {
     if (!this.#links.reply) {
       throw TypeError(
-        i18next.t("{{link_name}} link missing from resource.", {
-          link_name: "Reply",
+        i18next.t("{{linkName}} link missing from resource.", {
+          linkName: "Reply",
         })
       );
     }


### PR DESCRIPTION
* fix extract ui msg create wrongly split msgs.

:heart: Thank you for your contribution!

### Description

* backport: https://github.com/inveniosoftware/invenio-requests/pull/621
* related: https://github.com/inveniosoftware/invenio-app-rdm/issues/3499
* realted: https://github.com/inveniosoftware/invenio-app-rdm/issues/3506



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
