### PR TITLE
fix(comments): resolve collisions in allowed tags configuration

### DIFF
--- a/invenio_requests/customizations/event_types.py
+++ b/invenio_requests/customizations/event_types.py
@@ -40,10 +40,10 @@ class RequestsCommentsSanitizedHTML(utils_fields.SanitizedHTML):
             current_app.config.get("ALLOWED_HTML_TAGS", [])
             + current_app.config["REQUESTS_COMMENTS_ALLOWED_EXTRA_HTML_TAGS"]
         )
-        self.attrs = self.attrs = dict(
+        self.attrs = {
             **current_app.config.get("ALLOWED_HTML_ATTRS", {}),
             **current_app.config["REQUESTS_COMMENTS_ALLOWED_EXTRA_HTML_ATTRS"],
-        )
+        }
 
         return super()._deserialize(value, attr, data, **kwargs)
 


### PR DESCRIPTION
Previously, the `_deserialize()` method would crash if the `REQUESTS_COMMENTS_ALLOWED_EXTRA_HTML_ATTRS` keys had an overlap with the `ALLOWED_HTML_ATTRS` config; e.g. if both included `img`.

* the `dict()` function cannot handle receiving multiple values for a keyword argument with the same name; it will raise a `TypeError`
* the dictionary literal (`{**d1, **d2}`) does support multiple values for the same key however, with the latest value overriding earlier values
* this seems to be the semantic that we want here, to have the more specific configuration `REQUESTS_COMMENTS_ALLOWED_EXTRA_HTML_ATTRS` take precendence over the more general `ALLOWED_HTML_ATTRS`